### PR TITLE
fix(client): Correct API env var name in .env.example

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,2 +1,2 @@
-VITE_API_URL=http://localhost:5000/api
+VITE_API_BASE_URL=http://localhost:5000/api
 VITE_APP_NAME=French Learning Platform


### PR DESCRIPTION
Changed VITE_API_URL to VITE_API_BASE_URL in client/.env.example to match usage in contentService.ts. This ensures developers use the correct environment variable when setting up their local .env file.