### PR TITLE
Fix quiz display by mapping API data to QuizData

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { Container, Typography, Paper, CircularProgress, Alert, Box } from '@mui/material';
 import { getUserProfile, UserProfileData } from '../services/authService';
-import { fetchSampleQuiz } from '../services/contentService';
+import { getTopics, getContentForTopic } from '../services/contentService';
 import Quiz, { QuizData } from './Quiz';
+import { ApiContentItem, mapApiContentToQuizData } from '../utils/data-mappers';
 
 // Use UserProfileData from authService to ensure consistency
 // If UserProfileData needs optional email, it should be defined there.
@@ -13,18 +14,20 @@ const Dashboard: React.FC = () => {
   const [user, setUser] = useState<UserProfileData | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  const [quizData, setQuizData] = useState<QuizData[] | null>(null);
+  const [topics, setTopics] = useState<Array<{ id: number; name: string }>>([]);
+  const [quizzes, setQuizzes] = useState<QuizData[]>([]);
+  const [selectedTopicId, setSelectedTopicId] = useState<number | null>(null);
 
   useEffect(() => {
-    const fetchUserData = async () => {
+    const fetchInitialData = async () => {
       try {
         setLoading(true);
         const userData = await getUserProfile();
         setUser(userData);
-        const quiz = await fetchSampleQuiz();
-        setQuizData(quiz);
-      } catch (err: any) { // Explicitly type err as any or a more specific error type
-        console.error("Failed to fetch user data:", err);
+        const topicList = await getTopics();
+        setTopics(topicList);
+      } catch (err: any) {
+        console.error('Failed to fetch dashboard data:', err);
         const message = err.message || 'Failed to load user information. Please try again later.';
         setError(message);
       } finally {
@@ -32,8 +35,26 @@ const Dashboard: React.FC = () => {
       }
     };
 
-    fetchUserData();
+    fetchInitialData();
   }, []);
+
+  const handleTopicClick = async (topicId: number) => {
+    try {
+      setSelectedTopicId(topicId);
+      setLoading(true);
+      const content: ApiContentItem[] = await getContentForTopic(topicId);
+      const quizzesOnly = content.filter(
+        (item) => item.type === 'multiple-choice' || item.type === 'quiz'
+      );
+      const mapped = quizzesOnly.map(mapApiContentToQuizData);
+      setQuizzes(mapped);
+    } catch (err: any) {
+      console.error('Error fetching topic content:', err);
+      setError('Failed to load quizzes for this topic.');
+    } finally {
+      setLoading(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -60,11 +81,28 @@ const Dashboard: React.FC = () => {
         <Typography variant="body1">
           This is your personal dashboard. Here you will find your progress, available quizzes, and more.
         </Typography>
-        {quizData && (
-          <Box sx={{ mt: 4 }}>
-            <Quiz quizData={quizData[0]} />
-          </Box>
-        )}
+        <Box sx={{ mt: 4 }}>
+          {topics.map((topic) => (
+            <Typography
+              key={topic.id}
+              variant="h6"
+              sx={{ cursor: 'pointer', mb: 1 }}
+              onClick={() => handleTopicClick(topic.id)}
+            >
+              {topic.name}
+            </Typography>
+          ))}
+        </Box>
+        <Box sx={{ mt: 4 }}>
+          {selectedTopicId && quizzes.length === 0 && (
+            <Typography>No quizzes found for this topic.</Typography>
+          )}
+          {quizzes.map((quiz) => (
+            <Box key={quiz.id} sx={{ mb: 3 }}>
+              <Quiz quizData={quiz} />
+            </Box>
+          ))}
+        </Box>
       </Paper>
     </Container>
   );

--- a/client/src/services/contentService.ts
+++ b/client/src/services/contentService.ts
@@ -14,4 +14,14 @@ export const fetchSampleQuiz = async () => {
   return response.data;
 };
 
+export const getTopics = async () => {
+  const response = await apiClient.get('/content/topics');
+  return response.data;
+};
+
+export const getContentForTopic = async (topicId: number | string) => {
+  const response = await apiClient.get(`/content/topics/${topicId}/content`);
+  return response.data;
+};
+
 export default apiClient;

--- a/client/src/utils/data-mappers.ts
+++ b/client/src/utils/data-mappers.ts
@@ -1,0 +1,36 @@
+export interface ApiContentItem {
+  id: string;
+  type: string;
+  topic: string;
+  difficultyLevel?: string;
+  tags?: string[];
+  questionData: {
+    text: string;
+    explanation: string;
+  };
+  options: string[];
+  correctAnswer: number;
+  feedback?: {
+    correct: string;
+    incorrect: string;
+  };
+}
+
+import { QuizData } from '../components/Quiz';
+
+export function mapApiContentToQuizData(item: ApiContentItem): QuizData {
+  return {
+    id: item.id,
+    type: item.type,
+    topic: item.topic,
+    difficulty: item.difficultyLevel || '',
+    tags: item.tags || [],
+    question: {
+      text: item.questionData.text,
+      explanation: item.questionData.explanation,
+    },
+    options: item.options,
+    correct_answer: item.correctAnswer,
+    feedback: item.feedback || { correct: '', incorrect: '' },
+  };
+}


### PR DESCRIPTION
## Summary
- add API->QuizData mapper
- fetch topics and quizzes on the dashboard
- load quizzes for selected topic
- expose topic and content fetching in `contentService`

## Testing
- `npm --prefix server install`
- `npm --prefix server test` *(fails: User API Endpoints tests)*
- `npm --prefix client install`
- `npm --prefix client run build`

------
https://chatgpt.com/codex/tasks/task_e_6852e3743e5c83239ff319c983c7ccee