### PR TITLE
Fix migrations path

### DIFF
--- a/server/knexfile.ts
+++ b/server/knexfile.ts
@@ -12,10 +12,10 @@ const config: { [key: string]: Knex.Config } = {
     },
     useNullAsDefault: true,
     migrations: {
-      directory: path.resolve(__dirname, '../database/migrations'),
+      directory: path.resolve(__dirname, '../..', 'database', 'migrations'),
     },
     seeds: {
-      directory: path.resolve(__dirname, '../database/seeds'),
+      directory: path.resolve(__dirname, '../..', 'database', 'seeds'),
     },
   },
 
@@ -26,10 +26,10 @@ const config: { [key: string]: Knex.Config } = {
     },
     useNullAsDefault: true,
     migrations: {
-      directory: path.resolve(__dirname, '../database/migrations'),
+      directory: path.resolve(__dirname, '../..', 'database', 'migrations'),
     },
     seeds: {
-      directory: path.resolve(__dirname, '../database/seeds'),
+      directory: path.resolve(__dirname, '../..', 'database', 'seeds'),
     },
   },
 };


### PR DESCRIPTION
## Summary
- correct migrations path in server/knexfile.ts so Jest uses proper migrations directory

## Testing
- `npm install` in server
- `npm test --silent` *(fails: expected values didn't match)*

------
https://chatgpt.com/codex/tasks/task_e_68541d33af8483239e37f62ae1e9f7cd