### PR TITLE
Implement admin content & topic CRUD API

### DIFF
--- a/server/src/controllers/admin.controller.ts
+++ b/server/src/controllers/admin.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import knex from '../config/db';
 
+import { createContent, getContentById, getAllContent, updateContent, deleteContent } from '../models/Content';
 interface AnalyticsSummary {
   totalUsers: number;
   usersByRole: { role: string; count: number }[];
@@ -68,5 +69,118 @@ export const createTopic = async (req: Request, res: Response): Promise<void> =>
   } catch (error) {
     console.error('Error creating topic:', error);
     res.status(500).json({ message: 'Failed to create topic' });
+  }
+};
+
+export const getTopicById = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const topic = await knex('topics').where({ id }).first();
+    if (!topic) {
+      res.status(404).json({ message: 'Topic not found' });
+      return;
+    }
+    res.status(200).json(topic);
+  } catch (error) {
+    console.error('Error fetching topic:', error);
+    res.status(500).json({ message: 'Failed to fetch topic' });
+  }
+};
+
+export const updateTopicById = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    await knex('topics').where({ id }).update(req.body);
+    const updated = await knex('topics').where({ id }).first();
+    if (!updated) {
+      res.status(404).json({ message: 'Topic not found' });
+      return;
+    }
+    res.status(200).json(updated);
+  } catch (error) {
+    console.error('Error updating topic:', error);
+    res.status(500).json({ message: 'Failed to update topic' });
+  }
+};
+
+export const deleteTopicById = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const deleted = await knex('topics').where({ id }).del();
+    if (!deleted) {
+      res.status(404).json({ message: 'Topic not found' });
+      return;
+    }
+    res.status(204).send();
+  } catch (error) {
+    console.error('Error deleting topic:', error);
+    res.status(500).json({ message: 'Failed to delete topic' });
+  }
+};
+
+
+
+export const createContentItem = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const newItem = await createContent(req.body);
+    res.status(201).json(newItem);
+  } catch (error) {
+    console.error('Error creating content:', error);
+    res.status(500).json({ message: 'Failed to create content' });
+  }
+};
+
+export const getAllContentItems = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const items = await getAllContent();
+    res.status(200).json(items);
+  } catch (error) {
+    console.error('Error fetching content items:', error);
+    res.status(500).json({ message: 'Failed to fetch content items' });
+  }
+};
+
+export const getContentItemById = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const item = await getContentById(Number(id));
+    if (!item) {
+      res.status(404).json({ message: 'Content not found' });
+      return;
+    }
+    res.status(200).json(item);
+  } catch (error) {
+    console.error('Error fetching content:', error);
+    res.status(500).json({ message: 'Failed to fetch content' });
+  }
+};
+
+export const updateContentItemById = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const updated = await updateContent(Number(id), req.body);
+    if (!updated) {
+      res.status(404).json({ message: 'Content not found' });
+      return;
+    }
+    res.status(200).json(updated);
+  } catch (error) {
+    console.error('Error updating content:', error);
+    res.status(500).json({ message: 'Failed to update content' });
+  }
+};
+
+export const deleteContentItemById = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const success = await deleteContent(Number(id));
+    if (!success) {
+      res.status(404).json({ message: 'Content not found' });
+      return;
+    }
+    res.status(204).send();
+  } catch (error) {
+    console.error('Error deleting content:', error);
+    res.status(500).json({ message: 'Failed to delete content' });
   }
 };

--- a/server/src/models/Content.ts
+++ b/server/src/models/Content.ts
@@ -92,3 +92,29 @@ export const createContent = async (contentData: NewContent): Promise<ContentApp
   }
   throw new Error('Content creation failed, ID not returned.');
 };
+
+export const getAllContent = async (): Promise<ContentApplicationData[]> => {
+  const items: ContentSchema[] = await db<ContentSchema>('content').select('*');
+  return items.map(mapContentToApplicationData);
+};
+
+export const updateContent = async (id: number, updateData: Partial<NewContent>): Promise<ContentApplicationData | null> => {
+  const dataToUpdate: Partial<ContentSchema> = {};
+  if (updateData.topic_id !== undefined) dataToUpdate.topic_id = updateData.topic_id;
+  if (updateData.type !== undefined) dataToUpdate.type = updateData.type;
+  if (updateData.question_data !== undefined) dataToUpdate.question_data = JSON.stringify(updateData.question_data);
+  if (updateData.correct_answer !== undefined) dataToUpdate.correct_answer = JSON.stringify(updateData.correct_answer);
+  if (updateData.options !== undefined) dataToUpdate.options = updateData.options ? JSON.stringify(updateData.options) : null;
+  if (updateData.difficulty_level !== undefined) dataToUpdate.difficulty_level = updateData.difficulty_level;
+  if (updateData.tags !== undefined) dataToUpdate.tags = updateData.tags ? JSON.stringify(updateData.tags) : null;
+  if (updateData.active !== undefined) dataToUpdate.active = updateData.active;
+
+  await db<ContentSchema>('content').where({ id }).update(dataToUpdate);
+  const updated = await db<ContentSchema>('content').where({ id }).first();
+  return updated ? mapContentToApplicationData(updated) : null;
+};
+
+export const deleteContent = async (id: number): Promise<boolean> => {
+  const count = await db<ContentSchema>('content').where({ id }).del();
+  return count > 0;
+};

--- a/server/src/models/Topic.ts
+++ b/server/src/models/Topic.ts
@@ -52,3 +52,13 @@ export const createTopic = async (topicData: NewTopic): Promise<TopicSchema> => 
   }
   return newTopic;
 };
+export const updateTopic = async (id: number, updateData: Partial<NewTopic>): Promise<TopicSchema | null> => {
+  await db<TopicSchema>('topics').where({ id }).update(updateData);
+  const updated = await db<TopicSchema>('topics').where({ id }).first();
+  return updated || null;
+};
+
+export const deleteTopic = async (id: number): Promise<boolean> => {
+  const rowsDeleted = await db<TopicSchema>('topics').where({ id }).del();
+  return rowsDeleted > 0;
+};

--- a/server/src/routes/admin.routes.ts
+++ b/server/src/routes/admin.routes.ts
@@ -1,12 +1,19 @@
-// server/src/routes/admin.routes.ts
 import express from 'express';
 import { protect } from '../middleware/auth.middleware';
 import { isAdmin } from '../middleware/admin.middleware';
-import { 
-    adminTestController, 
+import {
+    adminTestController,
     getAnalyticsSummary,
     getAllTopics,
-    createTopic
+    createTopic,
+    getTopicById,
+    updateTopicById,
+    deleteTopicById,
+    createContentItem,
+    getAllContentItems,
+    getContentItemById,
+    updateContentItemById,
+    deleteContentItemById
 } from '../controllers/admin.controller';
 
 const router = express.Router();
@@ -14,12 +21,21 @@ const router = express.Router();
 // Test route for admin access
 router.get('/test', protect, isAdmin, adminTestController);
 
-// Analytics summary route (already existed in controller, now formally routed)
+// Analytics summary route
 router.get('/analytics', protect, isAdmin, getAnalyticsSummary);
 
 // Topic management routes
 router.get('/topics', protect, isAdmin, getAllTopics);
 router.post('/topics', protect, isAdmin, createTopic);
+router.get('/topics/:id', protect, isAdmin, getTopicById);
+router.put('/topics/:id', protect, isAdmin, updateTopicById);
+router.delete('/topics/:id', protect, isAdmin, deleteTopicById);
 
+// Content management routes
+router.get('/content', protect, isAdmin, getAllContentItems);
+router.post('/content', protect, isAdmin, createContentItem);
+router.get('/content/:id', protect, isAdmin, getContentItemById);
+router.put('/content/:id', protect, isAdmin, updateContentItemById);
+router.delete('/content/:id', protect, isAdmin, deleteContentItemById);
 
 export default router;


### PR DESCRIPTION
## Summary
- add update & delete helpers in `Topic` model
- support listing, updating, and removing content items in `Content` model
- expand admin controller with full CRUD handlers
- wire up new admin routes for content and topics

## Testing
- `npm test --silent --prefix server` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68551092c5a48323ae1216ee6f773169