### PR TITLE
Fix DB migration and script paths

### DIFF
--- a/database/migrations/20250619155421_rename_name_to_title_in_topics.js
+++ b/database/migrations/20250619155421_rename_name_to_title_in_topics.js
@@ -1,11 +1,26 @@
-exports.up = function(knex) {
-  return knex.schema.table('topics', function(table) {
-    table.renameColumn('name', 'title');
-  });
+// This migration originally renamed the `name` column in the `topics` table to
+// `title`.  The rest of the codebase, however, still expects the column to be
+// called `name`.  Running the original migration would therefore break queries
+// and tests.  To keep new installs consistent with the current code we instead
+// ensure the column is named `name`.  If a previous install already renamed the
+// column to `title`, running this migration will rename it back.
+
+exports.up = async function (knex) {
+  const hasTitle = await knex.schema.hasColumn('topics', 'title');
+  const hasName = await knex.schema.hasColumn('topics', 'name');
+  if (hasTitle && !hasName) {
+    await knex.schema.table('topics', function (table) {
+      table.renameColumn('title', 'name');
+    });
+  }
 };
 
-exports.down = function(knex) {
-  return knex.schema.table('topics', function(table) {
-    table.renameColumn('title', 'name');
-  });
+exports.down = async function (knex) {
+  const hasName = await knex.schema.hasColumn('topics', 'name');
+  const hasTitle = await knex.schema.hasColumn('topics', 'title');
+  if (hasName && !hasTitle) {
+    await knex.schema.table('topics', function (table) {
+      table.renameColumn('name', 'title');
+    });
+  }
 };

--- a/scripts/clear_content.ts
+++ b/scripts/clear_content.ts
@@ -1,5 +1,8 @@
 import knex from 'knex';
-import knexConfig from '../server/knexfile';
+// Import the Knex configuration from the server project.  The file lives under
+// `server/src` but older scripts referenced `../server/knexfile` which no
+// longer exists after the TypeScript refactor.
+import knexConfig from '../server/src/knexfile';
 
 // Initialize Knex with the development configuration
 const db = knex(knexConfig.development);

--- a/scripts/populate_content.ts
+++ b/scripts/populate_content.ts
@@ -1,7 +1,10 @@
 import knex from 'knex';
 import fs from 'fs/promises';
 import path from 'path';
-import knexConfig from '../server/knexfile';
+// Import the Knex configuration from the server project.  Older versions of
+// this script referenced `../server/knexfile`, but the actual file lives under
+// `server/src`.
+import knexConfig from '../server/src/knexfile';
 
 // Initialize Knex with the development configuration
 const db = knex(knexConfig.development);

--- a/scripts/run-migration.ts
+++ b/scripts/run-migration.ts
@@ -1,5 +1,8 @@
 const knex = require('knex');
-const knexConfig = require('../server/knexfile');
+// The Knex configuration was moved under `server/src`.  Require the TypeScript
+// file directly so `ts-node` can execute migrations without a missing module
+// error.
+const knexConfig = require('../server/src/knexfile');
 
 const db = knex(knexConfig.development);
 


### PR DESCRIPTION
## Summary
- correct outdated path to knexfile in automation scripts
- keep `topics` table column name consistent

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858090fcfcc8323b7184d51191b1601