### PR TITLE
Refactor auth pages and centralize theming

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link, useNavigate, useLocation } from 'react-router-dom';
-import { AppBar, Toolbar, Button, Container, CssBaseline, Typography } from '@mui/material'; // Added Typography
+import { AppBar, Toolbar, Button, Container, Typography } from '@mui/material';
 import { getCurrentUser, isAuthenticated, logout as authLogout } from './services/authService';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
@@ -56,7 +56,6 @@ const AppContent: React.FC = () => {
 
   return (
     <>
-      <CssBaseline />
       <AppBar position="static">
         <Toolbar>
           {isUserAuthenticated ? (

--- a/client/src/ThemeProvider.tsx
+++ b/client/src/ThemeProvider.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, useMemo, useState, ReactNode } from 'react';
+import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
+
+export type ThemeMode = 'light' | 'dark';
+
+interface ThemeContextValue {
+  mode: ThemeMode;
+  toggleMode: () => void;
+  setMode: (mode: ThemeMode) => void;
+}
+
+export const ThemeModeContext = createContext<ThemeContextValue>({
+  mode: 'light',
+  toggleMode: () => {},
+  setMode: () => {},
+});
+
+interface Props {
+  children: ReactNode;
+}
+
+const ThemeProviderWrapper: React.FC<Props> = ({ children }) => {
+  const [mode, setModeState] = useState<ThemeMode>(() => {
+    const stored = localStorage.getItem('themeMode');
+    return stored === 'dark' ? 'dark' : 'light';
+  });
+
+  const setMode = (newMode: ThemeMode) => {
+    localStorage.setItem('themeMode', newMode);
+    setModeState(newMode);
+  };
+
+  const toggleMode = () => {
+    setMode(mode === 'light' ? 'dark' : 'light');
+  };
+
+  const theme = useMemo(
+    () =>
+      createTheme({
+        palette: { mode },
+      }),
+    [mode]
+  );
+
+  const contextValue = useMemo(() => ({ mode, toggleMode, setMode }), [mode]);
+
+  return (
+    <ThemeModeContext.Provider value={contextValue}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </ThemeModeContext.Provider>
+  );
+};
+
+export default ThemeProviderWrapper;

--- a/client/src/components/UserPreferencesForm.tsx
+++ b/client/src/components/UserPreferencesForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { getUserPreferences, saveUserPreferences } from '../services/userService';
 import { UserPreferences } from '../types/Preference';
 import {
@@ -13,8 +13,10 @@ import {
   CircularProgress,
   Snackbar,
 } from '@mui/material';
+import { ThemeModeContext } from '../ThemeProvider';
 
 const UserPreferencesForm: React.FC = () => {
+  const { setMode } = useContext(ThemeModeContext);
   const [preferences, setPreferences] = useState<UserPreferences>({
     theme: 'light',
     notifications: { email: false },
@@ -28,7 +30,10 @@ const UserPreferencesForm: React.FC = () => {
       try {
         const data = await getUserPreferences();
         if (data && Object.keys(data).length > 0) {
-            setPreferences(data);
+          setPreferences(data);
+          if (data.theme) {
+            setMode(data.theme);
+          }
         }
       } catch (err) {
         setError('Failed to load preferences.');
@@ -42,9 +47,11 @@ const UserPreferencesForm: React.FC = () => {
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, checked } = event.target;
-    
+
     if (name === 'theme') {
-        setPreferences(prev => ({ ...prev, theme: prev.theme === 'dark' ? 'light' : 'dark' }));
+        const newMode = preferences.theme === 'dark' ? 'light' : 'dark';
+        setPreferences(prev => ({ ...prev, theme: newMode }));
+        setMode(newMode);
     } else {
         const [category, key] = name.split('.');
         if (category === 'notifications' && (key === 'email' || key === 'sms')) {

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import './index.css'; // Global styles, including Tailwind
+import './index.css';
 import App from './App';
+import ThemeProviderWrapper from './ThemeProvider';
 // import reportWebVitals from './reportWebVitals'; // Optional: for performance measuring
 
 const rootElement = document.getElementById('root');
@@ -12,7 +13,9 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProviderWrapper>
+      <App />
+    </ThemeProviderWrapper>
   </React.StrictMode>
 );
 

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,6 +1,15 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { login } from '../services/authService'; // Import the login service
+import {
+  TextField,
+  Button,
+  Container,
+  Paper,
+  Box,
+  Typography,
+  Alert,
+} from '@mui/material';
+import { login } from '../services/authService';
 
 const LoginPage: React.FC = () => {
   const [email, setEmail] = useState('');
@@ -12,113 +21,60 @@ const LoginPage: React.FC = () => {
     event.preventDefault();
     setError(null);
     try {
-      // The authService expects 'password_hash', but for login, we send 'password'.
-      // This might need adjustment based on the actual backend API contract.
-      // For now, assuming the service or backend can handle 'password' or we adjust the service.
-      // Let's assume the service's LoginPayload should be { email: string, password_hash: string }
-      // but we are sending { email: string, password: string } to the backend endpoint.
-      const normalizedEmail = email.trim().toLowerCase(); // Trim whitespace and convert to lowercase
+      const normalizedEmail = email.trim().toLowerCase();
       const response = await login({ email: normalizedEmail, password });
       console.log('Login successful:', response);
-      // Token is stored by authService, navigate to dashboard
       navigate('/dashboard', { replace: true });
       window.location.reload();
     } catch (apiError: any) {
-      // Log the actual error object to see its structure if it's not what's expected
-      console.error('Login failed raw error:', apiError); 
-      // Ensure apiError has a message property, otherwise provide a default
-      const errorMessage = apiError && apiError.message 
-        ? apiError.message 
+      console.error('Login failed raw error:', apiError);
+      const errorMessage = apiError && apiError.message
+        ? apiError.message
         : 'Login failed. Please check your credentials or contact support.';
       setError(errorMessage);
     }
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8 bg-white p-10 rounded-xl shadow-lg">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-            Sign in to your account
-          </h2>
-        </div>
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          {error && <p className="text-red-500 text-sm text-center">{error}</p>}
-          <input type="hidden" name="remember" defaultValue="true" />
-          <div className="rounded-md shadow-sm -space-y-px">
-            <div>
-              <label htmlFor="email-address" className="sr-only">
-                Email address
-              </label>
-              <input
-                id="email-address"
-                name="email"
-                type="email"
-                autoComplete="email"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="Email address"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-              />
-            </div>
-            <div>
-              <label htmlFor="password" className="sr-only">
-                Password
-              </label>
-              <input
-                id="password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="Password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
-            </div>
-          </div>
-
-          {/* <div className="flex items-center justify-between">
-            <div className="flex items-center">
-              <input
-                id="remember-me"
-                name="remember-me"
-                type="checkbox"
-                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
-              />
-              <label htmlFor="remember-me" className="ml-2 block text-sm text-gray-900">
-                Remember me
-              </label>
-            </div>
-
-            <div className="text-sm">
-              <a href="#" className="font-medium text-indigo-600 hover:text-indigo-500">
-                Forgot your password?
-              </a>
-            </div>
-          </div> */}
-
-          <div>
-            <button
-              type="submit"
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-            >
-              Sign in
-            </button>
-          </div>
-        </form>
-        <div className="text-sm text-center">
-          <p>
-            Don't have an account?{' '}
-            <Link to="/register" className="font-medium text-indigo-600 hover:text-indigo-500">
-              Sign up
-            </Link>
-          </p>
-        </div>
-      </div>
-    </div>
+    <Container maxWidth="sm" sx={{ mt: 8 }}>
+      <Paper elevation={3} sx={{ p: 4 }}>
+        <Typography variant="h5" component="h1" align="center" gutterBottom>
+          Sign in to your account
+        </Typography>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+        <Box component="form" onSubmit={handleSubmit}>
+          <TextField
+            label="Email Address"
+            type="email"
+            fullWidth
+            margin="normal"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <TextField
+            label="Password"
+            type="password"
+            fullWidth
+            margin="normal"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
+            Sign in
+          </Button>
+        </Box>
+        <Typography align="center" sx={{ mt: 2 }}>
+          Don't have an account?{' '}
+          <Link to="/register">Sign up</Link>
+        </Typography>
+      </Paper>
+    </Container>
   );
 };
 

--- a/client/src/pages/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage.tsx
@@ -1,6 +1,15 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { register } from '../services/authService'; // Import the register service
+import {
+  TextField,
+  Button,
+  Container,
+  Paper,
+  Box,
+  Typography,
+  Alert,
+} from '@mui/material';
+import { register } from '../services/authService';
 
 const RegisterPage: React.FC = () => {
   const [firstName, setFirstName] = useState('');
@@ -28,7 +37,6 @@ const RegisterPage: React.FC = () => {
         lastName,
       });
       console.log('Registration successful:', response);
-      // Token is stored by authService, navigate to dashboard
       navigate('/dashboard');
     } catch (apiError: any) {
       console.error('Registration failed:', apiError);
@@ -37,107 +45,70 @@ const RegisterPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8 bg-white p-10 rounded-xl shadow-lg">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-            Create your account
-          </h2>
-        </div>
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          {error && <p className="text-red-500 text-sm text-center">{error}</p>}
-          <div className="rounded-md shadow-sm -space-y-px">
-            <div>
-              <label htmlFor="firstName" className="sr-only">First Name</label>
-              <input
-                id="firstName"
-                name="firstName"
-                type="text"
-                autoComplete="given-name"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="First Name"
-                value={firstName}
-                onChange={(e) => setFirstName(e.target.value)}
-              />
-            </div>
-            <div>
-              <label htmlFor="lastName" className="sr-only">Last Name</label>
-              <input
-                id="lastName"
-                name="lastName"
-                type="text"
-                autoComplete="family-name"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="Last Name"
-                value={lastName}
-                onChange={(e) => setLastName(e.target.value)}
-              />
-            </div>
-            <div>
-              <label htmlFor="email-address" className="sr-only">Email address</label>
-              <input
-                id="email-address"
-                name="email"
-                type="email"
-                autoComplete="email"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="Email address"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-              />
-            </div>
-            <div>
-              <label htmlFor="password" className="sr-only">Password</label>
-              <input
-                id="password"
-                name="password"
-                type="password"
-                autoComplete="new-password"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="Password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
-            </div>
-            <div>
-              <label htmlFor="confirm-password" className="sr-only">Confirm Password</label>
-              <input
-                id="confirm-password"
-                name="confirm-password"
-                type="password"
-                autoComplete="new-password"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-                placeholder="Confirm Password"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-              />
-            </div>
-          </div>
-
-          <div>
-            <button
-              type="submit"
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-            >
-              Sign up
-            </button>
-          </div>
-        </form>
-        <div className="text-sm text-center">
-          <p>
-            Already have an account?{' '}
-            <Link to="/login" className="font-medium text-indigo-600 hover:text-indigo-500">
-              Sign in
-            </Link>
-          </p>
-        </div>
-      </div>
-    </div>
+    <Container maxWidth="sm" sx={{ mt: 8 }}>
+      <Paper elevation={3} sx={{ p: 4 }}>
+        <Typography variant="h5" component="h1" align="center" gutterBottom>
+          Create your account
+        </Typography>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+        <Box component="form" onSubmit={handleSubmit}>
+          <TextField
+            label="First Name"
+            fullWidth
+            margin="normal"
+            required
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+          />
+          <TextField
+            label="Last Name"
+            fullWidth
+            margin="normal"
+            required
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+          />
+          <TextField
+            label="Email Address"
+            type="email"
+            fullWidth
+            margin="normal"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <TextField
+            label="Password"
+            type="password"
+            fullWidth
+            margin="normal"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <TextField
+            label="Confirm Password"
+            type="password"
+            fullWidth
+            margin="normal"
+            required
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+          />
+          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
+            Sign up
+          </Button>
+        </Box>
+        <Typography align="center" sx={{ mt: 2 }}>
+          Already have an account?{' '}
+          <Link to="/login">Sign in</Link>
+        </Typography>
+      </Paper>
+    </Container>
   );
 };
 


### PR DESCRIPTION
## Summary
- add new `ThemeProvider` with context for light/dark mode
- wrap app in theme provider
- refactor Login/Register pages to use Material UI components
- hook user preferences to theme
- remove duplicate `CssBaseline`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68580dd9bbb48323825cc76384348767