### PR TITLE
Fix merge conflict leftovers in quiz components

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -116,11 +116,7 @@ const Dashboard: React.FC = () => {
           )}
           {content.map((contentItem) => (
             <Box key={contentItem.id} sx={{ mb: 3 }}>
-<<<<<<< HEAD
-              <Quiz content={contentItem} />
-=======
               <Quiz content={contentItem} onAnswer={handleAnswer} />
->>>>>>> main
             </Box>
           ))}
         </Box>

--- a/client/src/components/Quiz.tsx
+++ b/client/src/components/Quiz.tsx
@@ -1,32 +1,13 @@
 import React from 'react';
-<<<<<<< HEAD
-import { Content, MultipleChoiceData, FillInTheBlankData, TrueFalseData } from '../types/Content';
-import MultipleChoiceQuiz from './quiz_types/MultipleChoiceQuiz';
-import FillInTheBlankQuiz from './quiz_types/FillInTheBlankQuiz';
-import TrueFalseQuiz from './quiz_types/TrueFalseQuiz';
-=======
 import { Content } from '../types/Content';
 import MultipleChoiceQuiz from './quiz_types/MultipleChoiceQuiz';
 import FillInTheBlankQuiz from './quiz_types/FillInTheBlankQuiz';
 import TrueFalseQuiz from './quiz_types/TrueFalseQuiz';
 import SentenceCorrectionQuiz from './quiz_types/SentenceCorrectionQuiz';
->>>>>>> main
 import { Typography } from '@mui/material';
 
 interface QuizProps {
   content: Content;
-<<<<<<< HEAD
-}
-
-const Quiz: React.FC<QuizProps> = ({ content }) => {
-  switch (content.type) {
-    case 'multiple-choice':
-      return <MultipleChoiceQuiz data={content.questionData as MultipleChoiceData} />;
-    case 'fill-in-the-blank':
-      return <FillInTheBlankQuiz data={content.questionData as FillInTheBlankData} />;
-    case 'true-false':
-      return <TrueFalseQuiz data={content.questionData as TrueFalseData} />;
-=======
   onAnswer: (isCorrect: boolean) => void;
 }
 
@@ -40,7 +21,6 @@ const Quiz: React.FC<QuizProps> = ({ content, onAnswer }) => {
       return <TrueFalseQuiz content={content} onAnswer={onAnswer} />;
     case 'sentence-correction':
       return <SentenceCorrectionQuiz content={content} onAnswer={onAnswer} />;
->>>>>>> main
     default:
       return <Typography>Unsupported content type: {content.type}</Typography>;
   }

--- a/client/src/components/quiz_types/FillInTheBlankQuiz.tsx
+++ b/client/src/components/quiz_types/FillInTheBlankQuiz.tsx
@@ -8,17 +8,6 @@ import {
   Box,
   Alert,
 } from '@mui/material';
-<<<<<<< HEAD
-import { FillInTheBlankData } from '../../types/Content';
-
-interface FillInTheBlankQuizProps {
-  data: FillInTheBlankData;
-}
-
-const FillInTheBlankQuiz: React.FC<FillInTheBlankQuizProps> = ({ data }) => {
-  const [answer, setAnswer] = useState('');
-  const [isSubmitted, setIsSubmitted] = useState(false);
-=======
 import { Content, FillInTheBlankData } from '../../types/Content';
 
 interface FillInTheBlankQuizProps {
@@ -30,7 +19,6 @@ const FillInTheBlankQuiz: React.FC<FillInTheBlankQuizProps> = ({ content, onAnsw
   const [answer, setAnswer] = useState('');
   const [isSubmitted, setIsSubmitted] = useState(false);
   const data = content.questionData as FillInTheBlankData;
->>>>>>> main
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setAnswer(event.target.value);
@@ -38,13 +26,9 @@ const FillInTheBlankQuiz: React.FC<FillInTheBlankQuizProps> = ({ content, onAnsw
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-<<<<<<< HEAD
-    setIsSubmitted(true);
-=======
     const isCorrect = answer.trim().toLowerCase() === data.correctAnswer.toLowerCase();
     setIsSubmitted(true);
     onAnswer(isCorrect);
->>>>>>> main
   };
 
   const isCorrect = isSubmitted && answer.trim().toLowerCase() === data.correctAnswer.toLowerCase();

--- a/client/src/components/quiz_types/MultipleChoiceQuiz.tsx
+++ b/client/src/components/quiz_types/MultipleChoiceQuiz.tsx
@@ -11,17 +11,6 @@ import {
   Box,
   Alert,
 } from '@mui/material';
-<<<<<<< HEAD
-import { MultipleChoiceData } from '../../types/Content';
-
-interface MultipleChoiceQuizProps {
-  data: MultipleChoiceData;
-}
-
-const MultipleChoiceQuiz: React.FC<MultipleChoiceQuizProps> = ({ data }) => {
-  const [selectedValue, setSelectedValue] = useState<string>('');
-  const [isSubmitted, setIsSubmitted] = useState(false);
-=======
 import { Content, MultipleChoiceData } from '../../types/Content';
 
 interface MultipleChoiceQuizProps {
@@ -33,7 +22,6 @@ const MultipleChoiceQuiz: React.FC<MultipleChoiceQuizProps> = ({ content, onAnsw
   const [selectedValue, setSelectedValue] = useState<string>('');
   const [isSubmitted, setIsSubmitted] = useState(false);
   const data = content.questionData as MultipleChoiceData;
->>>>>>> main
 
   const handleRadioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSelectedValue(event.target.value);
@@ -41,14 +29,10 @@ const MultipleChoiceQuiz: React.FC<MultipleChoiceQuizProps> = ({ content, onAnsw
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-<<<<<<< HEAD
-    setIsSubmitted(true);
-=======
     const selectedOptionIndex = data.options.indexOf(selectedValue);
     const isCorrect = selectedOptionIndex === data.correctAnswer;
     setIsSubmitted(true);
     onAnswer(isCorrect);
->>>>>>> main
   };
 
   const selectedOptionIndex = data.options.indexOf(selectedValue);

--- a/client/src/components/quiz_types/TrueFalseQuiz.tsx
+++ b/client/src/components/quiz_types/TrueFalseQuiz.tsx
@@ -11,17 +11,6 @@ import {
   Box,
   Alert,
 } from '@mui/material';
-<<<<<<< HEAD
-import { TrueFalseData } from '../../types/Content';
-
-interface TrueFalseQuizProps {
-  data: TrueFalseData;
-}
-
-const TrueFalseQuiz: React.FC<TrueFalseQuizProps> = ({ data }) => {
-  const [selectedValue, setSelectedValue] = useState<string>('');
-  const [isSubmitted, setIsSubmitted] = useState(false);
-=======
 import { Content, TrueFalseData } from '../../types/Content';
 
 interface TrueFalseQuizProps {
@@ -33,7 +22,6 @@ const TrueFalseQuiz: React.FC<TrueFalseQuizProps> = ({ content, onAnswer }) => {
   const [selectedValue, setSelectedValue] = useState<string>('');
   const [isSubmitted, setIsSubmitted] = useState(false);
   const data = content.questionData as TrueFalseData;
->>>>>>> main
 
   const handleRadioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSelectedValue(event.target.value);
@@ -41,13 +29,9 @@ const TrueFalseQuiz: React.FC<TrueFalseQuizProps> = ({ content, onAnswer }) => {
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-<<<<<<< HEAD
-    setIsSubmitted(true);
-=======
     const isCorrect = (selectedValue === 'true') === data.correctAnswer;
     setIsSubmitted(true);
     onAnswer(isCorrect);
->>>>>>> main
   };
 
   const isCorrect = isSubmitted && (selectedValue === 'true') === data.correctAnswer;


### PR DESCRIPTION
## Summary
- remove leftover conflict markers in Dashboard and quiz components
- ensure quiz components accept content and onAnswer props

## Testing
- `npm --prefix client install`
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_68594610f60483239bbe8ffed2e53fce