### PR TITLE
Seed example data with default users

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,17 @@ Follow these instructions to get a local copy of the project up and running for 
 
 3.  **Set up the database:**
     This command will run all necessary database migrations and seed the database with initial content.
+    The seed includes a few example topics, exercises and assignments and creates default user accounts.
     ```sh
     npm run db:setup
     ```
+    The preloaded accounts are:
+
+    | Email | Password | Role |
+    |-------|----------|------|
+    | `admin@example.com` | `admin` | admin |
+    | `user@example.com` | `user` | user |
+
     If you encounter errors like `no such table: users` when running the
     application, ensure the migrations have been applied by executing:
     ```sh

--- a/database/seeds/02_users.ts
+++ b/database/seeds/02_users.ts
@@ -1,0 +1,26 @@
+import { Knex } from 'knex';
+import bcrypt from 'bcryptjs';
+
+export async function seed(knex: Knex): Promise<void> {
+  await knex('users').del();
+
+  const adminHash = await bcrypt.hash('admin', 10);
+  const userHash = await bcrypt.hash('user', 10);
+
+  await knex('users').insert([
+    {
+      email: 'admin@example.com',
+      password_hash: adminHash,
+      first_name: 'admin',
+      last_name: 'example',
+      role: 'admin',
+    },
+    {
+      email: 'user@example.com',
+      password_hash: userHash,
+      first_name: 'user',
+      last_name: 'example',
+      role: 'user',
+    },
+  ]);
+}

--- a/database/seeds/03_topics.ts
+++ b/database/seeds/03_topics.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+export async function seed(knex: Knex): Promise<void> {
+  await knex('topics').del();
+
+  await knex('topics').insert([
+    {
+      name: 'Greetings',
+      description: 'Common French greetings and introductions',
+    },
+    {
+      name: 'Food and Dining',
+      description: 'Vocabulary related to eating out and cooking',
+    },
+    {
+      name: 'Travel',
+      description: 'Phrases for traveling around France',
+    },
+  ]);
+}

--- a/database/seeds/04_content.ts
+++ b/database/seeds/04_content.ts
@@ -1,0 +1,64 @@
+import { Knex } from 'knex';
+
+export async function seed(knex: Knex): Promise<void> {
+  await knex('content').del();
+
+  const greetings = await knex('topics').where({ name: 'Greetings' }).first();
+  const food = await knex('topics').where({ name: 'Food and Dining' }).first();
+  const travel = await knex('topics').where({ name: 'Travel' }).first();
+
+  if (!greetings || !food || !travel) {
+    throw new Error('Required topics missing for content seed');
+  }
+
+  await knex('content').insert([
+    {
+      name: 'greeting_evening',
+      topic_id: greetings.id,
+      content_type_id: 1,
+      question_data: JSON.stringify({
+        text: "Which phrase means 'Good evening' in French?",
+        explanation: 'Basic greeting vocabulary',
+        feedback: {
+          correct: "Correct! 'Bonsoir' is used in the evening.",
+          incorrect: "Remember that 'Bonsoir' is specifically used in the evening."
+        }
+      }),
+      correct_answer: JSON.stringify(1),
+      options: JSON.stringify(['Bonjour', 'Bonsoir', 'Bonne nuit']),
+      difficulty_level: 'A1'
+    },
+    {
+      name: 'food_phrase_blank',
+      topic_id: food.id,
+      content_type_id: 2,
+      question_data: JSON.stringify({
+        text: 'Je voudrais manger un _____ au fromage.',
+        explanation: 'Use the correct food item',
+        feedback: {
+          correct: 'Great!',
+          incorrect: "The correct word is 'sandwich'."
+        }
+      }),
+      correct_answer: JSON.stringify('sandwich'),
+      options: null,
+      difficulty_level: 'A1'
+    },
+    {
+      name: 'travel_sentence_fix',
+      topic_id: travel.id,
+      content_type_id: 3,
+      question_data: JSON.stringify({
+        text: "Corrigez la phrase: 'Je aller au musée demain.'",
+        explanation: "Conjugation of 'aller' in the near future",
+        feedback: {
+          correct: 'Parfait!',
+          incorrect: "It should be 'Je vais aller au musée demain.'"
+        }
+      }),
+      correct_answer: JSON.stringify('Je vais aller au musée demain.'),
+      options: null,
+      difficulty_level: 'A2'
+    }
+  ]);
+}

--- a/database/seeds/05_user_content_assignments.ts
+++ b/database/seeds/05_user_content_assignments.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex';
+
+export async function seed(knex: Knex): Promise<void> {
+  await knex('user_content_assignments').del();
+
+  const admin = await knex('users').where({ email: 'admin@example.com' }).first();
+  const user = await knex('users').where({ email: 'user@example.com' }).first();
+
+  const greet = await knex('content').where({ name: 'greeting_evening' }).first();
+  const food = await knex('content').where({ name: 'food_phrase_blank' }).first();
+  const travel = await knex('content').where({ name: 'travel_sentence_fix' }).first();
+
+  if (!admin || !user || !greet || !food || !travel) {
+    throw new Error('Missing prerequisite data for assignments seed');
+  }
+
+  await knex('user_content_assignments').insert([
+    { user_id: admin.id, content_id: greet.id, status: 'pending' },
+    { user_id: user.id, content_id: food.id, status: 'pending' },
+    { user_id: user.id, content_id: travel.id, status: 'pending' },
+  ]);
+}


### PR DESCRIPTION
## Summary
- seed users, topics, sample content and assignments
- document default user credentials in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859500b73a483239433d0da6ad45763