### PR TITLE
Dashboard Assigned Content Filtering and Topic Cards

### DIFF
--- a/client/src/components/AssignedContentList.tsx
+++ b/client/src/components/AssignedContentList.tsx
@@ -1,14 +1,32 @@
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { UserContentAssignmentWithContent } from '../types/Assignment';
-import { Typography, List, ListItem, ListItemText, Divider, Box, Button, ListItemButton } from '@mui/material';
+import {
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  Divider,
+  Box,
+  Button,
+  ListItemButton,
+  ListItemIcon,
+} from '@mui/material';
+import { formatDisplayName } from '../utils/textFormatters';
+import { getIconForType } from '../utils/iconMap';
 
 interface AssignedContentListProps {
   assignments: UserContentAssignmentWithContent[];
+  /** Number of items to display. Omit to show all */
+  limit?: number;
+  /** Whether to hide assignments with status === 'completed' */
+  showIncompleteOnly?: boolean;
 }
 
-const AssignedContentList: React.FC<AssignedContentListProps> = ({ assignments }) => {
-  if (assignments.length === 0) {
+const AssignedContentList: React.FC<AssignedContentListProps> = ({ assignments, limit, showIncompleteOnly = false }) => {
+  const filteredAssignments = showIncompleteOnly ? assignments.filter(a => a.status !== 'completed') : assignments;
+
+  if (filteredAssignments.length === 0) {
     return (
       <Box>
         <Typography variant="h5" component="h2" gutterBottom>
@@ -19,8 +37,7 @@ const AssignedContentList: React.FC<AssignedContentListProps> = ({ assignments }
     );
   }
 
-  // In a future step, this could be limited to e.g. 5 items on the dashboard
-  const itemsToShow = assignments;
+  const itemsToShow = typeof limit === 'number' ? filteredAssignments.slice(0, limit) : filteredAssignments;
 
   return (
     <Box>
@@ -31,10 +48,11 @@ const AssignedContentList: React.FC<AssignedContentListProps> = ({ assignments }
         {itemsToShow.map((assignment, index) => (
           <React.Fragment key={assignment.id}>
             <ListItem disablePadding>
-              <ListItemButton component={RouterLink} to={`/content/${assignment.content.id}`}>
+              <ListItemButton component={RouterLink} to={`/content/${assignment.content.id}`}> 
+                <ListItemIcon>{getIconForType(assignment.content.type)}</ListItemIcon>
                 <ListItemText
-                  primary={assignment.content.name}
-                  secondary={assignment.content.type}
+                  primary={formatDisplayName(assignment.content.name)}
+                  secondary={formatDisplayName(assignment.content.type)}
                 />
               </ListItemButton>
             </ListItem>
@@ -43,9 +61,9 @@ const AssignedContentList: React.FC<AssignedContentListProps> = ({ assignments }
         ))}
       </List>
       {/* This link is more useful on the dashboard view specifically */}
-      {assignments.length > itemsToShow.length && (
+      {filteredAssignments.length > itemsToShow.length && (
          <Button component={RouterLink} to="/assignments" sx={{ mt: 2 }}>
-           View All ({assignments.length})
+           View All ({filteredAssignments.length})
          </Button>
       )}
     </Box>

--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -1,24 +1,21 @@
 import React, { useEffect, useState } from 'react';
 import { Container, Typography, Paper, CircularProgress, Alert, Box } from '@mui/material';
 import { logout } from '../services/authService';
-import { getTopics, getContentForTopic, getAssignedContent } from '../services/contentService';
-import { recordContentCompletion, getCurrentUser } from '../services/userService';
+import { getTopics, getAssignedContent } from '../services/contentService';
+import { getCurrentUser } from '../services/userService';
 import { Topic } from '../types/Topic';
 import { User } from '../types/User';
-import { Link as RouterLink } from 'react-router-dom';
-import Quiz from './Quiz';
-import { Content } from '../types/Content';
+
 import AssignedContentList from './AssignedContentList';
 import { UserContentAssignmentWithContent } from '../types/Assignment';
 import ProgressAnalytics from './ProgressAnalytics';
+import ExploreTopics from './ExploreTopics';
 
 const Dashboard: React.FC = () => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [topics, setTopics] = useState<Topic[]>([]);
-  const [content, setContent] = useState<Content[]>([]);
-  const [selectedTopicId, setSelectedTopicId] = useState<number | null>(null);
   const [assignments, setAssignments] = useState<UserContentAssignmentWithContent[]>([]);
 
   useEffect(() => {
@@ -48,30 +45,7 @@ const Dashboard: React.FC = () => {
     fetchInitialData();
   }, []);
 
-  const handleTopicClick = async (topicId: number) => {
-    try {
-      setSelectedTopicId(topicId);
-      setLoading(true);
-      const topicContent: Content[] = await getContentForTopic(topicId);
-      setContent(topicContent);
-    } catch (err: any) {
-      console.error('Error fetching topic content:', err);
-      setError('Failed to load content for this topic.');
-    } finally {
-      setLoading(false);
-    }
-  };
 
-  const handleAnswer = (contentId: number, isCorrect: boolean) => {
-    console.log(`Answered content ${contentId}. Correct: ${isCorrect}`);
-    if (isCorrect) {
-      // If the answer is correct, call the service to record the completion.
-      // This is an optimistic update; we don't wait for it or handle errors
-      // in the UI to keep things simple, as per requirements.
-      // The progress will be visible on the next page load.
-      recordContentCompletion(contentId);
-    }
-  };
 
   if (loading) {
     return (
@@ -102,33 +76,15 @@ const Dashboard: React.FC = () => {
           <ProgressAnalytics />
         </Box>
         <Box sx={{ mt: 4 }}>
-          <AssignedContentList assignments={assignments} />
+          <AssignedContentList assignments={assignments} limit={5} showIncompleteOnly />
         </Box>
         <Box sx={{ mt: 4 }}>
           <Typography variant="h5" component="h2" gutterBottom>
             Explore Topics
           </Typography>
-          {topics.map((topic) => (
-            <Typography
-              key={topic.id}
-              variant="h6"
-              sx={{ cursor: 'pointer', mb: 1 }}
-              onClick={() => handleTopicClick(topic.id)}
-            >
-              {topic.name}
-            </Typography>
-          ))}
+          <ExploreTopics topics={topics} />
         </Box>
-        <Box sx={{ mt: 4 }}>
-          {selectedTopicId && content.length === 0 && (
-            <Typography>No content found for this topic.</Typography>
-          )}
-          {content.map((contentItem) => (
-            <Box key={contentItem.id} sx={{ mb: 3 }}>
-              <Quiz content={contentItem} onAnswer={(isCorrect) => handleAnswer(contentItem.id, isCorrect)} />
-            </Box>
-          ))}
-        </Box>
+        {/* Topic content preview has been removed in favor of dedicated pages */}
       </Paper>
     </Container>
   );

--- a/client/src/components/ExploreTopics.tsx
+++ b/client/src/components/ExploreTopics.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Card, CardContent, Typography, CardActions, Button } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { Topic } from '../types/Topic';
+import { formatDisplayName } from '../utils/textFormatters';
+
+interface ExploreTopicsProps {
+  topics: Topic[];
+}
+
+const ExploreTopics: React.FC<ExploreTopicsProps> = ({ topics }) => {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+      {topics.map(topic => (
+        <Card key={topic.id} sx={{ minWidth: 200 }}>
+          <CardContent>
+            <Typography variant="h6" component="div">
+              {formatDisplayName(topic.name)}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {topic.description}
+            </Typography>
+          </CardContent>
+          <CardActions>
+            <Button size="small" component={RouterLink} to={`/topics/${topic.id}/learn`}>
+              View Content
+            </Button>
+          </CardActions>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default ExploreTopics;

--- a/client/src/pages/AllAssignmentsPage.tsx
+++ b/client/src/pages/AllAssignmentsPage.tsx
@@ -14,7 +14,6 @@ const AllAssignmentsPage: React.FC = () => {
       try {
         setLoading(true);
         const allAssignments = await getAssignedContent();
-        // TODO: Filter for incomplete assignments once status is available
         setAssignments(allAssignments);
         setError(null);
       } catch (err) {

--- a/client/src/utils/iconMap.tsx
+++ b/client/src/utils/iconMap.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import FormatListNumberedIcon from '@mui/icons-material/FormatListNumbered';
+import EditIcon from '@mui/icons-material/Edit';
+import KeyboardIcon from '@mui/icons-material/Keyboard';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import DescriptionIcon from '@mui/icons-material/Description';
+
+export const iconMap: Record<string, React.ComponentType> = {
+  'multiple-choice': FormatListNumberedIcon,
+  'sentence-correction': EditIcon,
+  'fill-in-the-blank': KeyboardIcon,
+  'true-false': CheckCircleOutlineIcon,
+};
+
+export const getIconForType = (type: string): React.ReactElement => {
+  const IconComponent = iconMap[type] || DescriptionIcon;
+  return <IconComponent />;
+};

--- a/client/src/utils/textFormatters.ts
+++ b/client/src/utils/textFormatters.ts
@@ -1,0 +1,8 @@
+export const formatDisplayName = (text: string): string => {
+  if (!text) return '';
+  return text
+    .replace(/[-_]/g, ' ')
+    .split(' ')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};


### PR DESCRIPTION
## Summary
- add `formatDisplayName` utility
- add icon mapping for content types
- filter incomplete assignments in `AssignedContentList` and add icons
- create `ExploreTopics` component with topic cards
- integrate new components into dashboard

## Testing
- `npm --prefix client run build`
- `npm --prefix server run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685acee070d48323bd3a520133a0e2f1