### PR TITLE
Fix assignment listing

### DIFF
--- a/client/src/components/AssignedContentList.tsx
+++ b/client/src/components/AssignedContentList.tsx
@@ -51,7 +51,7 @@ const AssignedContentList: React.FC<AssignedContentListProps> = ({ assignments, 
               <ListItemButton component={RouterLink} to={`/content/${assignment.content.id}`}> 
                 <ListItemIcon>{getIconForType(assignment.content.type)}</ListItemIcon>
                 <ListItemText
-                  primary={formatDisplayName(assignment.content.name)}
+                  primary={formatDisplayName(assignment.content.title || assignment.content.name)}
                   secondary={formatDisplayName(assignment.content.type)}
                 />
               </ListItemButton>

--- a/client/src/components/admin/AssignmentManager.tsx
+++ b/client/src/components/admin/AssignmentManager.tsx
@@ -154,7 +154,7 @@ const AssignmentManager: React.FC = () => {
             ) : (
               assignments.map(assignment => (
                 <TableRow key={assignment.id}>
-                  <TableCell>{assignment.content.name}</TableCell>
+                  <TableCell>{assignment.content.title || assignment.content.name}</TableCell>
                   <TableCell>{assignment.content.type}</TableCell>
                   <TableCell>{assignment.status}</TableCell>
                   <TableCell align="right">

--- a/client/src/services/adminService.ts
+++ b/client/src/services/adminService.ts
@@ -240,7 +240,8 @@ export interface UserContentAssignment {
   user_id: number;
   content_id: number;
   assigned_at: string;
-  status: string;
+  due_date?: string;
+  status: 'pending' | 'in-progress' | 'completed' | 'overdue';
 }
 
 export interface UserContentAssignmentWithContent extends UserContentAssignment {

--- a/client/src/services/contentService.ts
+++ b/client/src/services/contentService.ts
@@ -41,12 +41,14 @@ export const getContentById = async (id: number | string) => {
   return response.data;
 };
 
-export const getAssignedContent = async () => {
+import { UserContentAssignmentWithContent } from '../types/Assignment';
+
+export const getAssignedContent = async (): Promise<UserContentAssignmentWithContent[]> => {
   const token = localStorage.getItem('authToken');
   if (!token) {
     throw new Error('No token found');
   }
-  const response = await apiClient.get('/users/me/assignments', {
+  const response = await apiClient.get<UserContentAssignmentWithContent[]>('/users/me/assignments', {
     headers: {
       Authorization: `Bearer ${token}`,
     },

--- a/client/src/types/Assignment.ts
+++ b/client/src/types/Assignment.ts
@@ -5,7 +5,8 @@ export interface UserContentAssignment {
   user_id: number;
   content_id: number;
   assigned_at: Date;
-  status: 'pending' | 'completed';
+  due_date?: Date;
+  status: 'pending' | 'in-progress' | 'completed' | 'overdue';
 }
 
 export interface UserContentAssignmentWithContent extends UserContentAssignment {

--- a/server/src/models/UserContentAssignment.ts
+++ b/server/src/models/UserContentAssignment.ts
@@ -43,7 +43,8 @@ const UserContentAssignmentModel = {
       .join('content', 'user_content_assignments.content_id', 'content.id')
       .select(
         'user_content_assignments.*',
-        'content.title as content_name',
+        'content.name as content_slug_name',
+        'content.title as content_display_title',
         'content.question_data as content_question_data',
         'content.id as content_id_alias'
       );
@@ -67,13 +68,22 @@ const UserContentAssignmentModel = {
     };
 
     return assignments.map(assignment => {
-      const { content_name, content_question_data, content_id_alias, content_type_id, content_type_name, ...assignmentData } = assignment;
+      const {
+        content_slug_name,
+        content_display_title,
+        content_question_data,
+        content_id_alias,
+        content_type_id,
+        content_type_name,
+        ...assignmentData
+      } = assignment;
       const type = content_type_name || (content_type_id ? typeIdMap[content_type_id] : undefined) || 'default';
       return {
         ...assignmentData,
         content: {
           id: content_id_alias,
-          name: content_name,
+          name: content_slug_name,
+          title: content_display_title,
           question_data: content_question_data,
           content_type_id: content_type_id,
           type,


### PR DESCRIPTION
## Summary
- return slug and title in assignment lookups
- show assignment titles in dashboard and admin
- expose due date and status enums in client types
- type assigned-content service calls

## Testing
- `npm --prefix server test`
- `npm --prefix server run build`
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_685bd1b44ee88323be2cd642f81b3b43