### PR TITLE
fix(learning-path): resolve lesson progress query error

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "migrate": "npx ts-node --project server/tsconfig.json scripts/run-migration.ts",
     "db:status": "npm --prefix server run db:status",
     "db:reset": "powershell -Command \"Remove-Item -Path database/french_learning.db -Force -ErrorAction SilentlyContinue\"",
-    "db:setup": "npm run db:reset && npm run migrate && npm run db:status && npm --prefix server run db:seed"
+    "db:seed": "npm --prefix server run db:seed",
+    "db:setup": "npm run migrate; npm run db:seed; npm run db:status"
   },
   "keywords": [],
   "author": "",

--- a/server/src/services/learningPathService.ts
+++ b/server/src/services/learningPathService.ts
@@ -70,10 +70,17 @@ export async function getLearningPathUserView(
   }
 
   // 3. Fetch All Relevant User Lesson Progress in One Go
-  const lessonIds = unitsAndLessonsRaw.map(item => item.lesson_id);
-  const userProgressRecords = await db<UserLessonProgress>('user_lesson_progress')
-    .where('user_id', userId)
-    .whereIn('lesson_id', lessonIds);
+  const lessonIds = unitsAndLessonsRaw
+    .map(item => item.lesson_id)
+    .filter((id): id is number => id !== null && id !== undefined);
+    
+  let userProgressRecords: UserLessonProgress[] = [];
+
+  if (lessonIds.length > 0) {
+    userProgressRecords = await db<UserLessonProgress>('user_lesson_progress')
+      .where('user_id', userId)
+      .whereIn('lesson_id', lessonIds);
+  }
 
   // Create a map for quick progress lookup
   const progressMap = new Map<number, UserLessonProgress>();


### PR DESCRIPTION
This PR resolves an error that occurred when fetching lesson progress for a learning path with no lessons. The Knex.js 'whereIn' query now correctly handles empty or invalid lesson ID arrays. Additionally, the 'db:setup' script has been updated to prevent accidental database deletion.