### PR TITLE
docs: add camelCase migration phase2 tasks

### DIFF
--- a/docs/development_docs/camelCase_migration_plan.md
+++ b/docs/development_docs/camelCase_migration_plan.md
@@ -16,6 +16,8 @@ This document outlines a staged approach for migrating the entire project from s
 - **Modify database utilities** like `server/src/knexfile.ts` and any usage of `knexSnakeCaseMappers`.
 - **Verify** updated schema works in SQLite and is ready for future PostgreSQL migration.
 
+A detailed breakdown of tasks for this phase can be found under `docs/development_docs/tasks/camelCase-phase-2/`.
+
 ## Phase 3: Backend Code Refactor
 - **Models** in `server/src/models/` – update property names, query builders, and data mapping logic.
 - **Controllers and services** in `server/src/controllers/` and `server/src/services/` – change references to snake_case fields, remove case‑conversion helpers.

--- a/docs/development_docs/tasks/camelCase-phase-2/1-renaming-migrations.md
+++ b/docs/development_docs/tasks/camelCase-phase-2/1-renaming-migrations.md
@@ -1,0 +1,10 @@
+# Task CC2.1: Create Renaming Migrations
+
+- **Goal**: Introduce Knex migration files that rename all snake_case tables and columns to camelCase.
+- **Steps**:
+  1. Use the schema review from Phase 1 as a map of old names to new names.
+  2. Generate migration scripts in `database/migrations/` using `knex migrate:make`.
+  3. Within each script, call `renameTable` and `renameColumn` for every affected table and field.
+  4. Update related indexes and foreign key constraints in the same migration to reference the new names.
+  5. Include proper rollback logic so the migration can revert the names if needed.
+- **Deliverable**: A set of migration files under `database/migrations/` that safely rename tables, columns, indexes, and constraints to camelCase.

--- a/docs/development_docs/tasks/camelCase-phase-2/2-update-seeds.md
+++ b/docs/development_docs/tasks/camelCase-phase-2/2-update-seeds.md
@@ -1,0 +1,9 @@
+# Task CC2.2: Update Seed Data
+
+- **Goal**: Ensure all seed scripts insert data using the new camelCase schema.
+- **Steps**:
+  1. Search under `database/seeds/` for snake_case column names or table references.
+  2. Update each seed file to use camelCase keys and updated table names.
+  3. Verify relationship mappings (e.g., foreign keys) still align with the renamed schema.
+  4. Run `knex seed:run` locally after applying the renaming migrations to confirm the data loads correctly.
+- **Deliverable**: Updated seed files that populate the database successfully after the camelCase migrations.

--- a/docs/development_docs/tasks/camelCase-phase-2/3-adjust-db-utils.md
+++ b/docs/development_docs/tasks/camelCase-phase-2/3-adjust-db-utils.md
@@ -1,0 +1,9 @@
+# Task CC2.3: Refactor Database Utilities
+
+- **Goal**: Modify Knex configuration and helper utilities so they assume camelCase naming.
+- **Steps**:
+  1. Review `server/src/knexfile.ts` for usage of `knexSnakeCaseMappers` or similar utilities.
+  2. Remove or adjust these mappers so the application no longer auto-converts between cases.
+  3. Search `server/src/` for helper functions that transform snake_case results to camelCase and refactor them as needed.
+  4. Double-check environment-specific configs to ensure both SQLite and PostgreSQL use the same conventions.
+- **Deliverable**: Updated configuration and helper files that work with camelCase columns directly.

--- a/docs/development_docs/tasks/camelCase-phase-2/4-validate-migration.md
+++ b/docs/development_docs/tasks/camelCase-phase-2/4-validate-migration.md
@@ -1,0 +1,9 @@
+# Task CC2.4: Validate Schema Migration
+
+- **Goal**: Confirm that the new camelCase schema functions correctly in SQLite and remains compatible with PostgreSQL.
+- **Steps**:
+  1. Apply the renaming migrations and updated seeds in a fresh local environment.
+  2. Run the existing test suite with `npm --prefix server test` to catch regressions.
+  3. Spin up a PostgreSQL instance (e.g., via Docker) and run the same migrations to identify platform-specific issues.
+  4. Record any failures or discrepancies and update the migrations or configs accordingly.
+- **Deliverable**: A validation report summarizing test results and required adjustments for cross-database compatibility.


### PR DESCRIPTION
## Summary
- document tasks for Phase 2 of the camelCase migration
- reference the new tasks from the migration plan

## Testing
- `npm --prefix server test` *(fails: `no such table: topics` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685fb780fe50832389ee0276ea1c38f9