### PR TITLE
Add camelCase Phase 4 tasks

### DIFF
--- a/docs/development_docs/camelCase_migration_plan.md
+++ b/docs/development_docs/camelCase_migration_plan.md
@@ -33,6 +33,8 @@ A detailed breakdown of tasks for this phase can be found under `docs/developmen
 - **React components and pages** in `client/src/components/` and `client/src/pages/` – revise prop names, form fields, and API integrations.
 - **TypeScript types** in `client/src/types/` (if present) – ensure all interfaces use camelCase.
 
+A detailed breakdown of tasks for this phase can be found under `docs/development_docs/tasks/camelCase-phase-4/`.
+
 ## Phase 5: Testing and Validation
 - **Run backend test suite** via `npm --prefix server test` and update any failing tests.
 - **Add or adjust client-side tests** if applicable.

--- a/docs/development_docs/tasks/camelCase-phase-4/1-api-services-refactor.md
+++ b/docs/development_docs/tasks/camelCase-phase-4/1-api-services-refactor.md
@@ -1,0 +1,9 @@
+# Task CC4.1: Update API Service Layer
+
+- **Goal**: Ensure all client-side services send and receive camelCase fields only.
+- **Steps**:
+  1. Search `client/src/services/` for snake_case patterns using `grep '_' -R` to locate outdated field names.
+  2. Update request payload builders to use camelCase keys when sending data to the backend.
+  3. Adjust response handling logic and remove any utilities that convert snake_case to camelCase.
+  4. Verify TypeScript return types remain accurate after renaming.
+- **Deliverable**: Service modules in `client/src/services/` referencing camelCase properties exclusively.

--- a/docs/development_docs/tasks/camelCase-phase-4/2-context-hooks-refactor.md
+++ b/docs/development_docs/tasks/camelCase-phase-4/2-context-hooks-refactor.md
@@ -1,0 +1,9 @@
+# Task CC4.2: Refactor Context and Hooks
+
+- **Goal**: Align React context providers and custom hooks with camelCase naming.
+- **Steps**:
+  1. Search `client/src/context/` and `client/src/hooks/` for underscores in variable or property names.
+  2. Rename state variables, context values, and hook return fields to camelCase.
+  3. Update imports or consumers of these hooks so they match the new names.
+  4. Remove temporary case-conversion logic that maps snake_case API data.
+- **Deliverable**: Context modules and hooks that expose camelCase data throughout the application.

--- a/docs/development_docs/tasks/camelCase-phase-4/3-components-pages-refactor.md
+++ b/docs/development_docs/tasks/camelCase-phase-4/3-components-pages-refactor.md
@@ -1,0 +1,9 @@
+# Task CC4.3: Update Components and Pages
+
+- **Goal**: Migrate all React components and pages to use camelCase prop names and data fields.
+- **Steps**:
+  1. Search `client/src/components/` and `client/src/pages/` for snake_case prop names or form field identifiers.
+  2. Rename component props and update corresponding usages where they are consumed.
+  3. Adjust any form `name` attributes or input handlers to align with camelCase payloads.
+  4. Verify that integrations with services or hooks pass camelCase data end-to-end.
+- **Deliverable**: Components and page modules free of snake_case references.

--- a/docs/development_docs/tasks/camelCase-phase-4/4-update-types.md
+++ b/docs/development_docs/tasks/camelCase-phase-4/4-update-types.md
@@ -1,0 +1,9 @@
+# Task CC4.4: Update TypeScript Types
+
+- **Goal**: Ensure type definitions reflect the camelCase schema and API contract.
+- **Steps**:
+  1. Inspect interfaces in `client/src/types/` for snake_case property names.
+  2. Rename these properties to camelCase and update any derived types or enums.
+  3. Search the codebase for imports of the renamed interfaces and adjust references accordingly.
+  4. Compile the client (`npm --prefix client run build`) to confirm there are no type errors.
+- **Deliverable**: TypeScript definition files using camelCase properties with successful compilation.


### PR DESCRIPTION
## Summary
- detail tasks to migrate client-side code to camelCase
- reference new task folder in the overall migration plan

## Testing
- `npm --prefix server test` *(fails: Content and Auth API tests return 404)*

------
https://chatgpt.com/codex/tasks/task_e_685fbd9859a48323ae6c3eb7ca6312d6