### PR TITLE
Add Phase 5 testing tasks

### DIFF
--- a/docs/development_docs/camelCase_migration_plan.md
+++ b/docs/development_docs/camelCase_migration_plan.md
@@ -40,6 +40,8 @@ A detailed breakdown of tasks for this phase can be found under `docs/developmen
 - **Add or adjust client-side tests** if applicable.
 - **Manual QA**: verify that API responses and the UI operate correctly with camelCase data.
 
+A detailed breakdown of tasks for this phase can be found under `docs/development_docs/tasks/camelCase-phase-5/`.
+
 ## Phase 6: Deployment and Rollback Planning
 - **Database backups** before applying migrations.
 - **Continuous integration updates** if build scripts reference snake_case.

--- a/docs/development_docs/tasks/camelCase-phase-5/1-run-backend-tests.md
+++ b/docs/development_docs/tasks/camelCase-phase-5/1-run-backend-tests.md
@@ -1,0 +1,9 @@
+# Task CC5.1: Execute Backend Test Suite
+
+- **Goal**: Establish the baseline by running all server tests against the camelCase codebase.
+- **Steps**:
+  1. Ensure the latest migrations and seeds are applied locally.
+  2. Run `npm --prefix server test` and allow all tests to complete.
+  3. Note any failures, paying attention to assertions expecting snake_case keys.
+  4. Record stack traces or error messages for follow‑up.
+- **Deliverable**: A log or summary of failing tests to address in subsequent tasks.

--- a/docs/development_docs/tasks/camelCase-phase-5/2-update-server-tests.md
+++ b/docs/development_docs/tasks/camelCase-phase-5/2-update-server-tests.md
@@ -1,0 +1,9 @@
+# Task CC5.2: Refactor Backend Tests
+
+- **Goal**: Update failing server tests and fixtures to align with camelCase fields.
+- **Steps**:
+  1. Search `server/src/**/__tests__/` for snake_case properties in mocks or expectations.
+  2. Rename these properties to camelCase and adjust any helper utilities.
+  3. Re-run `npm --prefix server test` to verify each updated test passes.
+  4. Remove obsolete case-conversion logic from the test setup.
+- **Deliverable**: Passing server-side test suite that references camelCase data exclusively.

--- a/docs/development_docs/tasks/camelCase-phase-5/3-update-client-tests.md
+++ b/docs/development_docs/tasks/camelCase-phase-5/3-update-client-tests.md
@@ -1,0 +1,9 @@
+# Task CC5.3: Update Client-Side Tests
+
+- **Goal**: Ensure front-end tests reflect camelCase API contracts and component props.
+- **Steps**:
+  1. Search `client/src` for test files referencing snake_case fields using `grep '_' -R *.test*`.
+  2. Adjust mocks, fixtures, and assertions to camelCase naming.
+  3. Run the client test suite (e.g., `npm --prefix client test`) to confirm there are no failures.
+  4. Verify that mocked API calls and component props are consistent with the backend changes.
+- **Deliverable**: Client tests updated to expect camelCase data and passing successfully.

--- a/docs/development_docs/tasks/camelCase-phase-5/4-manual-qa.md
+++ b/docs/development_docs/tasks/camelCase-phase-5/4-manual-qa.md
@@ -1,0 +1,9 @@
+# Task CC5.4: Manual QA and Regression Testing
+
+- **Goal**: Validate application behavior through hands-on testing of key user flows.
+- **Steps**:
+  1. Start both the backend and frontend in development mode.
+  2. Walk through features such as registration, lesson progression, and progress tracking.
+  3. Inspect network requests in browser dev tools to confirm camelCase payloads.
+  4. Log any UI or API issues encountered, noting whether they relate to naming changes.
+- **Deliverable**: QA checklist documenting tested scenarios and any bugs discovered.

--- a/docs/development_docs/tasks/camelCase-phase-5/5-validation-report.md
+++ b/docs/development_docs/tasks/camelCase-phase-5/5-validation-report.md
@@ -1,0 +1,9 @@
+# Task CC5.5: Compile Validation Report
+
+- **Goal**: Summarize test outcomes and determine readiness for deployment.
+- **Steps**:
+  1. Collect results from automated tests and manual QA efforts.
+  2. Highlight remaining issues or regressions tied to the camelCase migration.
+  3. Document resolutions or workarounds for any outstanding problems.
+  4. Share the report with the team for sign-off before proceeding to deployment.
+- **Deliverable**: A written report outlining validation status and next steps.


### PR DESCRIPTION
## Summary
- flesh out Phase 5 of the camelCase migration plan
- document the set of backend and client testing tasks
- add manual QA and validation report steps

## Testing
- `npm --prefix server test` *(fails: jest not found)*
- `npm --prefix client test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685fc059bd808323934b775f24cd9176