### PR TITLE
Add deployment/rollback tasks

### DIFF
--- a/docs/development_docs/camelCase_migration_plan.md
+++ b/docs/development_docs/camelCase_migration_plan.md
@@ -47,4 +47,6 @@ A detailed breakdown of tasks for this phase can be found under `docs/developmen
 - **Continuous integration updates** if build scripts reference snake_case.
 - **Document rollback procedures** and update README or deployment docs as needed.
 
+A detailed breakdown of tasks for this phase can be found under `docs/development_docs/tasks/camelCase-phase-6/`.
+
 This phased approach aims to minimize disruptions while ensuring consistency across the database, backend, and frontend layers.

--- a/docs/development_docs/tasks/camelCase-phase-6/1-database-backups.md
+++ b/docs/development_docs/tasks/camelCase-phase-6/1-database-backups.md
@@ -1,0 +1,9 @@
+# Task CC6.1: Create Database Backups
+
+- **Goal**: Safeguard existing data before running camelCase migrations.
+- **Steps**:
+  1. Locate the development database file (default `server/database/french_learning.db`).
+  2. Use `sqlite3` to export a full copy: `sqlite3 path/to/french_learning.db ".backup backup_pre_camelcase.sqlite"`.
+  3. Store the backup in a secure location outside the repository.
+  4. Verify you can restore it with `sqlite3 backup_pre_camelcase.sqlite ".restore path/to/french_learning.db"`.
+- **Deliverable**: Verified backup file ensuring the database can be restored if migration issues arise.

--- a/docs/development_docs/tasks/camelCase-phase-6/2-update-ci-scripts.md
+++ b/docs/development_docs/tasks/camelCase-phase-6/2-update-ci-scripts.md
@@ -1,0 +1,9 @@
+# Task CC6.2: Update Continuous Integration Scripts
+
+- **Goal**: Ensure CI pipelines build and test against the camelCase schema.
+- **Steps**:
+  1. Inspect `.github/workflows/` and any other CI configs for scripts that reference snake_case tables or columns.
+  2. Modify these scripts so migrations run automatically before tests using `npm run migrate` or equivalent.
+  3. Remove deprecated utilities like `knexSnakeCaseMappers` if still present in the CI setup.
+  4. Trigger the pipeline to confirm the build passes with camelCase tables.
+- **Deliverable**: CI configuration that deploys or tests only the camelCase codebase without errors.

--- a/docs/development_docs/tasks/camelCase-phase-6/3-document-rollback.md
+++ b/docs/development_docs/tasks/camelCase-phase-6/3-document-rollback.md
@@ -1,0 +1,8 @@
+# Task CC6.3: Document Rollback Procedures
+
+- **Goal**: Provide a clear path to revert the migration if unforeseen issues occur.
+- **Steps**:
+  1. Outline commands to roll back the latest Knex migration using `knex migrate:rollback`.
+  2. Describe how to restore the database backup created in Task CC6.1.
+  3. Note any environment variables or configuration changes that also need reverting.
+- **Deliverable**: Section in `docs/DEPLOYMENT.md` detailing step‑by‑step rollback instructions.

--- a/docs/development_docs/tasks/camelCase-phase-6/4-update-deployment-docs.md
+++ b/docs/development_docs/tasks/camelCase-phase-6/4-update-deployment-docs.md
@@ -1,0 +1,8 @@
+# Task CC6.4: Finalize Deployment Documentation
+
+- **Goal**: Ensure all public docs reflect camelCase conventions and deployment steps.
+- **Steps**:
+  1. Search `README.md` and `docs/DEPLOYMENT.md` for outdated snake_case examples or references.
+  2. Update command snippets and configuration paths to match the camelCase schema.
+  3. Include notes on when to run backups and where to find rollback instructions.
+- **Deliverable**: Updated documentation in the repository root that guides deployers through the camelCase rollout.


### PR DESCRIPTION
## Summary
- add `camelCase-phase-6` task folder
- document database backup, CI updates, rollback procedure, and deployment docs
- reference new tasks from the migration plan

## Testing
- `npm --prefix server test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc649572483239703a610b39d1e21