### PR TITLE
Simplify home dashboard layout and data mapping

### DIFF
--- a/client/src/hooks/useAIDashboard.ts
+++ b/client/src/hooks/useAIDashboard.ts
@@ -1,6 +1,6 @@
 import { useReducer, useEffect, useCallback, useMemo } from 'react';
 import { AIDashboardState, AIDashboardAction, AIGenerationJob } from '../types/AIDashboard.js';
-import api from '../services/api.js';
+import api from '../services/api';
 
 /**
  * Initial state for the AI Dashboard hook

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,314 +1,97 @@
-/**
- * Modern Dashboard with Sophisticated Lesson Cards
- * 
- * PHASE 4 TRANSFORMATION: AI dashboard → Modern lesson card interface with gamification
- * Infrastructure-First Approach: 95% code reuse through enhanced existing components
- * 
- * Key features implemented:
- * - Modern lesson card interface with progress rings and difficulty badges
- * - AI-powered lesson recommendations using existing infrastructure
- * - Gamification elements with XP rewards and progress tracking
- * - Responsive grid layout: 4-column desktop, 3-column tablet, 2-column mobile
- * - Design system compliant with sophisticated card styling
- * - Performance optimization through component reuse and memoization
- * - Accessibility compliance (WCAG 2.1) with enhanced ARIA support
- * 
- * @fileoverview Modern Dashboard with Enhanced Lesson Cards
- * @version 4.0.0 - Sophisticated Lesson Card Interface (Phase 4)
- * @author French Learning Platform Team
- */
-
 import React, { useCallback, useMemo } from 'react';
-import { Box, Alert, Snackbar, Typography } from '@mui/material';
-import { AIDashboardLayout, AIEnhancedHeader } from '../components/ai-dashboard/AIDashboardLayout.js';
-import { QuickActionsGrid } from '../components/ai-dashboard/QuickActionCard.js';
-import type { DifficultyLevel, LessonStatus } from '../components/ai-dashboard/QuickActionCard.js';
-import { AITutorCard } from '../components/ai-dashboard/AITutorCard.js';
-import { DashboardSkeleton } from '../components/ai-dashboard/LoadingStates.js';
-import { useOfflineDetection } from '../hooks/useOfflineDetection.js';
-import { useAIDashboard } from '../hooks/useAIDashboard.js';
+import { Box, Typography, Snackbar, Alert } from '@mui/material';
+import { AIDashboardLayout, AIEnhancedHeader } from '../components/ai-dashboard/AIDashboardLayout';
+import { DashboardSkeleton } from '../components/ai-dashboard/LoadingStates';
+import { useOfflineDetection } from '../hooks/useOfflineDetection';
+import { useAIDashboard } from '../hooks/useAIDashboard';
+import type { ContentType } from '../config/aiDashboardConfig';
+import {
+  resolveActivePlan,
+  selectFocusAreas,
+  buildPlanLessons,
+  selectNextLesson,
+  calculateDailyGoal,
+  calculatePlanConfidence,
+  buildHeroMetrics,
+  buildPlanSummary,
+  buildSkillInsights,
+  buildStudyGuidance,
+  mapQuickActions,
+  mapRecommendationsToLessons,
+  getUserSnapshot,
+  getFocusToken,
+} from './home/selectors';
+import {
+  PlanOverviewCard,
+  MetricsSection,
+  FocusJourneySection,
+  QuickActionsSection,
+  SkillInsightsSection,
+  TutorAndGuidance,
+} from './home/components';
+
 import '../styles/design-tokens.css';
 
-/**
- * Enhanced lesson card data structure
- * Maps lesson content types to appropriate icons and metadata
- */
-const LESSON_CONTENT_MAPPING = {
-  vocabulary: { icon: '📝', baseXp: 25, baseDifficulty: 'beginner' as DifficultyLevel },
-  grammar: { icon: '📚', baseXp: 35, baseDifficulty: 'intermediate' as DifficultyLevel },
-  conversation: { icon: '💬', baseXp: 45, baseDifficulty: 'advanced' as DifficultyLevel },
-  pronunciation: { icon: '🗣️', baseXp: 30, baseDifficulty: 'beginner' as DifficultyLevel },
-  exercise: { icon: '✏️', baseXp: 40, baseDifficulty: 'intermediate' as DifficultyLevel },
-  lesson: { icon: '👋', baseXp: 50, baseDifficulty: 'beginner' as DifficultyLevel },
-  reading: { icon: '📖', baseXp: 35, baseDifficulty: 'intermediate' as DifficultyLevel },
-  listening: { icon: '🎧', baseXp: 40, baseDifficulty: 'intermediate' as DifficultyLevel }
-} as const;
-
-/**
- * AI-powered personalization messages
- * Provides contextual learning insights based on user progress and lesson type
- */
-const AI_PERSONALIZATION_MESSAGES = [
-  "Perfect for your current level",
-  "Builds on your recent progress", 
-  "Recommended based on your learning style",
-  "Great way to practice new concepts",
-  "Focuses on your improvement areas",
-  "Ideal next step in your journey",
-  "Matches your study preferences",
-  "Strengthens your weak points"
-] as const;
-
-/**
- * Fallback lesson data for demonstration when API returns no recommendations
- * This showcases the sophisticated lesson card system we built
- * TODO: Remove once backend API is returning proper recommendation data
- */
-const FALLBACK_LESSON_DATA = [
-  {
-    id: 'lesson-greetings-demo',
-    title: 'French Greetings',
-    description: 'Master common French greetings and introductions',
-    type: 'vocabulary',
-    estimatedTime: 15
-  },
-  {
-    id: 'lesson-past-tense-demo',
-    title: 'Past Tense Mastery',
-    description: 'Learn passé composé and imparfait usage',
-    type: 'grammar',
-    estimatedTime: 25
-  },
-  {
-    id: 'lesson-conversation-demo',
-    title: 'Conversation Practice',
-    description: 'Real-world French conversation scenarios',
-    type: 'conversation',
-    estimatedTime: 20
-  },
-  {
-    id: 'lesson-subjunctive-demo',
-    title: 'Subjunctive Practice',
-    description: 'Master the French subjunctive mood',
-    type: 'grammar',
-    estimatedTime: 30
-  },
-  {
-    id: 'lesson-pronunciation-demo',
-    title: 'Pronunciation Guide',
-    description: 'Perfect your French accent and pronunciation',
-    type: 'pronunciation',
-    estimatedTime: 18
-  },
-  {
-    id: 'lesson-reading-demo',
-    title: 'Reading Comprehension',
-    description: 'Improve your French reading skills',
-    type: 'reading',
-    estimatedTime: 22
-  }
-];
-
-/**
- * Modern Dashboard with Sophisticated Lesson Cards
- * 
- * TRANSFORMATION: Enhanced lesson card system with gamification and progress tracking
- * APPROACH: Infrastructure-First with 95% existing code reuse through component enhancement
- * 
- * Key enhancements:
- * - Sophisticated lesson cards with progress rings and difficulty badges  
- * - AI-powered personalization using existing recommendation engine
- * - Gamification elements with XP rewards and status tracking
- * - Modern responsive grid layout matching design mockups
- * - Enhanced accessibility with comprehensive ARIA support
- * - Performance optimization through intelligent memoization
- */
 const HomePage: React.FC = () => {
   const { isOffline } = useOfflineDetection();
-  
-  // REUSE: Existing AI Dashboard state management hook with full feature set
   const {
     dailyPlan,
     recommendations,
-    isLoading: dashboardLoading,
-    error: dashboardError,
-    clearError
+    isLoading,
+    error,
+    clearError,
   } = useAIDashboard();
 
-  // Enhanced user data with gamification elements
-  const userData = useMemo(() => ({
-    userName: undefined, // Will be populated from auth context
-    progressPercentage: 75,
-    currentStreak: 7,
-    weeklyXp: 350,
-    totalXp: 2847,
-    dailyGoalProgress: {
-      current: 2,
-      target: 3,
-      percentage: 67
-    }
-  }), []);
+  const activePlan = useMemo(() => resolveActivePlan(dailyPlan), [dailyPlan]);
+  const focusAreas = useMemo(() => selectFocusAreas(activePlan), [activePlan]);
+  const planLessons = useMemo(() => buildPlanLessons(activePlan, focusAreas), [activePlan, focusAreas]);
+  const nextLesson = useMemo(() => selectNextLesson(planLessons), [planLessons]);
 
-  // Show loading skeleton during initial dashboard load
-  const showSkeleton = dashboardLoading && !recommendations.length;
+  const snapshot = useMemo(() => getUserSnapshot(), []);
+  const planConfidence = useMemo(() => calculatePlanConfidence(activePlan), [activePlan]);
+  const dailyGoal = useMemo(() => calculateDailyGoal(snapshot), [snapshot]);
+  const heroMetrics = useMemo(() => buildHeroMetrics(snapshot, planConfidence), [snapshot, planConfidence]);
+  const planSummary = useMemo(
+    () => buildPlanSummary(snapshot, activePlan, planLessons, planConfidence),
+    [snapshot, activePlan, planLessons, planConfidence],
+  );
+  const skillInsights = useMemo(() => buildSkillInsights(focusAreas), [focusAreas]);
+  const studyGuidance = useMemo(() => buildStudyGuidance(focusAreas), [focusAreas]);
+  const quickActions = useMemo(() => mapQuickActions(isOffline), [isOffline]);
+  const recommendedLessons = useMemo(
+    () => mapRecommendationsToLessons(recommendations, isOffline),
+    [recommendations, isOffline],
+  );
+  const focusChips = useMemo(
+    () => focusAreas.slice(0, 3).map((label) => ({ label, token: getFocusToken(label) })),
+    [focusAreas],
+  );
 
-  /**
-   * Generates AI-powered personalization message for lessons
-   * Uses simple randomization with content-type awareness
-   * 
-   * @param lessonType - The type of lesson content
-   * @param lessonIndex - Index for deterministic selection
-   * @returns Contextual personalization message
-   */
-  const generatePersonalization = useCallback((lessonType: string, lessonIndex: number): string => {
-    const messages = AI_PERSONALIZATION_MESSAGES;
-    // Use lesson index for deterministic but varied selection
-    const messageIndex = lessonIndex % messages.length;
-    return messages[messageIndex];
-  }, []);
+  const showSkeleton = isLoading && planLessons.length === 0 && recommendedLessons.length === 0;
 
-  /**
-   * Determines lesson status based on content and simulated progress
-   * Uses lesson index and type to simulate realistic learning progression
-   * 
-   * @param lessonIndex - Position in lesson array
-   * @param lessonType - Type of lesson content
-   * @returns Appropriate lesson status
-   */
-  const determineLessonStatus = useCallback((lessonIndex: number, lessonType: string): LessonStatus => {
-    // Simulate realistic lesson progression
-    if (lessonIndex === 0) return 'in_progress'; // First lesson in progress
-    if (lessonIndex === 1 && lessonType === 'conversation') return 'completed'; // One completed
-    if (lessonIndex <= 2) return 'not_started'; // Next lessons available
-    return 'locked'; // Future lessons locked
-  }, []);
-
-  /**
-   * Calculates lesson progress based on status and type
-   * Simulates realistic progress tracking
-   * 
-   * @param status - Current lesson status
-   * @param lessonIndex - Position for variation
-   * @returns Progress percentage (0-100)
-   */
-  const calculateLessonProgress = useCallback((status: LessonStatus, lessonIndex: number): number => {
-    switch (status) {
-      case 'completed': return 100;
-      case 'in_progress': return 40 + (lessonIndex * 10); // Varied progress
-      case 'review': return 100;
-      default: return 0;
-    }
-  }, []);
-
-  /**
-   * Enhanced lesson navigation with analytics tracking
-   * Handles lesson selection, progress tracking, and user flow
-   * 
-   * @param lessonId - Unique identifier for the lesson
-   * @param contentType - Type of lesson content for routing
-   */
-  const handleLessonNavigation = useCallback(async (lessonId: string, contentType?: string) => {
+  const handleQuickAction = useCallback((actionId: string, contentType: ContentType) => {
     if (isOffline) {
-      console.warn('[Navigation] Offline - lesson navigation blocked');
       return;
     }
-    
-    console.log(`[Navigation] Starting lesson: ${lessonId} (${contentType})`);
-    
-    try {
-      // TODO: Track lesson start analytics
-      // await api.post('/api/analytics/lesson-started', {
-      //   lessonId,
-      //   contentType,
-      //   source: 'dashboard',
-      //   timestamp: new Date().toISOString()
-      // });
-      
-      // TODO: Navigate to appropriate lesson interface
-      // const lessonRoute = contentType === 'conversation' ? 'conversation' : 'lesson';
-      // navigate(`/${lessonRoute}/${lessonId}`);
-      
-      // For now, simulate lesson start
-      console.log(`[Analytics] Lesson started: ${lessonId}`);
-      console.log(`[Route] Would navigate to: /lesson/${lessonId}`);
-      
-    } catch (error) {
-      console.error('[Navigation] Failed to start lesson:', error);
-    }
+
+    console.log('[Dashboard] Quick action selected', { actionId, contentType });
   }, [isOffline]);
 
-  /**
-   * TRANSFORMATION: Enhanced lesson card data with gamification
-   * APPROACH: Transform existing recommendations into sophisticated lesson cards, with fallback data
-   * FEATURES: Progress tracking, difficulty badges, XP rewards, AI personalization
-   */
-  const sophisticatedLessonCards = useMemo(() => {
-    // Use API recommendations if available, otherwise use fallback demo data
-    const lessonsToTransform = recommendations.length > 0 ? recommendations : FALLBACK_LESSON_DATA;
-    
-    return lessonsToTransform.map((lesson, index) => {
-      // Get lesson type configuration
-      const contentConfig = LESSON_CONTENT_MAPPING[lesson.type as keyof typeof LESSON_CONTENT_MAPPING] 
-        || LESSON_CONTENT_MAPPING.lesson;
-      
-      // Generate enhanced lesson properties
-      const status = determineLessonStatus(index, lesson.type);
-      const progress = calculateLessonProgress(status, index);
-      const aiPersonalization = generatePersonalization(lesson.type, index);
-      
-      // Calculate XP reward based on estimated time and difficulty
-      const timeMultiplier = Math.min(lesson.estimatedTime / 15, 2); // Cap at 2x
-      const xpReward = Math.round(contentConfig.baseXp * timeMultiplier);
-      
-      return {
-        id: lesson.id,
-        icon: contentConfig.icon,
-        title: lesson.title,
-        description: lesson.description,
-        contentType: lesson.type as any, // Type assertion for content type compatibility
-        estimatedTime: lesson.estimatedTime,
-        disabled: isOffline,
-        
-        // Enhanced lesson card properties
-        progress,
-        xpReward,
-        difficulty: contentConfig.baseDifficulty,
-        status,
-        aiPersonalization
-      };
-    });
-  }, [recommendations, isOffline, determineLessonStatus, calculateLessonProgress, generatePersonalization]);
-
-  /**
-   * Enhanced AI tutor interaction with context awareness
-   * Provides intelligent tutoring based on current lesson progress
-   */
-  const handleTutorInteraction = useCallback(() => {
+  const handlePlanLesson = useCallback((lessonId: string, contentType: string) => {
     if (isOffline) {
-      console.warn('[AI Tutor] Offline - interaction blocked');
       return;
     }
-    
-    console.log('[AI Tutor] Starting enhanced interaction session');
-    
-    try {
-      // TODO: Initialize context-aware AI session
-      const contextData = {
-        completedLessons: sophisticatedLessonCards.filter(l => l.status === 'completed').length,
-        currentDifficulty: 'beginner', // Would come from user profile
-        recentTopics: sophisticatedLessonCards.slice(0, 3).map(l => l.contentType),
-        dailyGoalProgress: userData.dailyGoalProgress
-      };
-      
-      console.log('[AI Tutor] Context data:', contextData);
-      
-      // TODO: Navigate to conversational AI interface
-      // navigate('/ai-tutor', { state: { context: contextData } });
-      
-    } catch (error) {
-      console.error('[AI Tutor] Failed to start interaction:', error);
+
+    console.log('[Dashboard] Plan lesson selected', { lessonId, contentType });
+  }, [isOffline]);
+
+  const handleTutorStart = useCallback(() => {
+    if (isOffline) {
+      return;
     }
-  }, [isOffline, sophisticatedLessonCards, userData.dailyGoalProgress]);
+
+    console.log('[Dashboard] Start AI tutor session');
+  }, [isOffline]);
 
   if (showSkeleton) {
     return <DashboardSkeleton />;
@@ -316,119 +99,103 @@ const HomePage: React.FC = () => {
 
   return (
     <AIDashboardLayout>
-      {/* REUSE: Existing enhanced header with dynamic content */}
-      <AIEnhancedHeader
-        userName={userData.userName}
-        progressPercentage={userData.progressPercentage}
-        currentStreak={userData.currentStreak}
-      />
-
-      {/* MODERN TRANSFORMATION: Sophisticated lesson card grid with gamification */}
-      <Box sx={{ p: 2 }}>
-        {/* Enhanced header with daily progress context */}
-        <Box sx={{ mb: 3 }}>
-          <Typography variant="h4" sx={{ fontWeight: 600, color: 'text.primary', mb: 1 }}>
-            Today's Learning Path
-          </Typography>
-          <Typography variant="body1" sx={{ color: 'text.secondary', mb: 2 }}>
-            Continue your French journey with personalized lessons
-          </Typography>
-          
-          {/* Daily progress indicator */}
-          {userData.dailyGoalProgress && (
-            <Box sx={{ 
-              display: 'flex', 
-              alignItems: 'center', 
-              gap: 'var(--spacing-lg)', 
-              p: 'var(--spacing-lg)', 
-              backgroundColor: 'var(--bg-secondary)',
-              borderRadius: 'var(--border-radius-small)',
-              border: '1px solid var(--border-light)'
-            }}>
-              <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                📈 Daily Progress: {userData.dailyGoalProgress.current}/{userData.dailyGoalProgress.target} lessons
-              </Typography>
-              <Box sx={{ 
-                flex: 1, 
-                height: 6, 
-                backgroundColor: 'var(--border-light)', 
-                borderRadius: 'var(--border-radius-small)',
-                overflow: 'hidden'
-              }}>
-                <Box sx={{ 
-                  width: `${userData.dailyGoalProgress.percentage}%`,
-                  height: '100%',
-                  backgroundColor: 'var(--color-success)',
-                  transition: 'width var(--transition-normal)'
-                }} />
-              </Box>
-              <Typography variant="body2" sx={{ color: 'var(--text-secondary)' }}>
-                {userData.dailyGoalProgress.percentage}%
-              </Typography>
-            </Box>
-          )}
-        </Box>
-        
-        {/* Always show lesson cards now that we have fallback data */}
-        {(
-          <QuickActionsGrid
-            actions={sophisticatedLessonCards}
-            onActionClick={handleLessonNavigation}
-            disabled={isOffline}
-            renderMode="lesson-card"      // ENHANCED: Use sophisticated lesson card mode
-            showProgress={true}           // ENABLE: Progress ring indicators
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: { xs: 'var(--spacing-6)', md: 'var(--spacing-8)' } }}>
+        <Box
+          component="section"
+          sx={{ display: 'grid', gap: 'var(--spacing-6)', gridTemplateColumns: { xs: '1fr', lg: '2fr 1fr' } }}
+        >
+          <AIEnhancedHeader
+            userName={snapshot.userName}
+            progressPercentage={snapshot.progressPercentage}
+            currentStreak={snapshot.streak}
             sx={{
-              // Enhanced responsive grid with larger, more prominent cards
-              display: 'grid',
-              gap: 3, // Increased spacing between cards
-              width: '100%',
-              // Desktop: 3 columns for better card size
-              gridTemplateColumns: 'repeat(3, 1fr)',
-              '@media (max-width: 1200px)': {
-                gridTemplateColumns: 'repeat(2, 1fr)', // 2 columns on smaller desktop/tablet
-              },
-              '@media (max-width: 768px)': {
-                gridTemplateColumns: '1fr', // Single column on mobile for full-width cards
-                gap: 2
-              },
-              // Ensure cards have minimum height for consistent appearance
-              '& > *': {
-                minHeight: '200px' // Taller cards for better visual prominence
-              }
+              minHeight: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
             }}
           />
-        )}
-        
-        {/* Debug information for development */}
-        {process.env.NODE_ENV === 'development' && (
-          <Box sx={{ mt: 2, p: 2, backgroundColor: '#f0f0f0', borderRadius: 1, fontSize: '0.8rem' }}>
-            <Typography variant="caption">
-              Debug: Using {recommendations.length > 0 ? 'API' : 'fallback'} lesson data. 
-              Cards loaded: {sophisticatedLessonCards.length}
-            </Typography>
-          </Box>
-        )}
-      </Box>
 
-      {/* ENHANCED: AI Tutor Card with context awareness */}
-      <Box sx={{ px: 2, pb: 2 }}>
-        <AITutorCard
-          userName={userData.userName}
-          progressPercentage={userData.progressPercentage}
-          onInteractionStart={handleTutorInteraction}
+          <PlanOverviewCard
+            nextLesson={nextLesson}
+            focusChips={focusChips}
+            dailyGoal={dailyGoal}
+            summary={planSummary}
+            lastLessonTitle={snapshot.lastLessonTitle}
+            isOffline={isOffline}
+            onStartLesson={handlePlanLesson}
+          />
+        </Box>
+
+        <Box component="section" sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-3)' }}>
+          <Typography variant="h5" sx={{ color: 'var(--text-primary)', fontWeight: 600 }}>
+            Today at a glance
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'var(--text-secondary)' }}>
+            Track your momentum and stay aligned with your plan.
+          </Typography>
+          <MetricsSection metrics={heroMetrics} />
+        </Box>
+
+        <Box component="section" sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-3)' }}>
+          <Typography variant="h5" sx={{ color: 'var(--text-primary)', fontWeight: 600 }}>
+            Today&apos;s focus journey
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'var(--text-secondary)' }}>
+            Move through the curated lessons to balance conversation, listening, and grammar.
+          </Typography>
+          <FocusJourneySection
+            lessons={planLessons}
+            onLessonClick={handlePlanLesson}
+            isOffline={isOffline}
+          />
+        </Box>
+
+        <QuickActionsSection
+          title="Quick practice boosts"
+          description="Need a fast refresher? Jump into a focused activity that fits your schedule."
+          actions={quickActions}
+          onActionClick={handleQuickAction}
           isOffline={isOffline}
+        />
+
+        <QuickActionsSection
+          title="Recommended for you"
+          description="AI-curated lessons crafted from your progress and preferred focus areas."
+          actions={recommendedLessons}
+          onActionClick={handleQuickAction}
+          isOffline={isOffline}
+          renderMode="lesson-card"
+          showProgress={recommendedLessons.some((lesson) => typeof lesson.progress === 'number')}
+        />
+
+        <Box component="section" sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-3)' }}>
+          <Typography variant="h5" sx={{ color: 'var(--text-primary)', fontWeight: 600 }}>
+            Skill insights
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'var(--text-secondary)' }}>
+            Visualise how your skills are evolving week over week.
+          </Typography>
+          <SkillInsightsSection insights={skillInsights} />
+        </Box>
+
+        <TutorAndGuidance
+          userName={snapshot.userName}
+          progressPercentage={snapshot.progressPercentage}
+          onStartTutor={handleTutorStart}
+          isOffline={isOffline}
+          highlights={studyGuidance}
         />
       </Box>
 
-      {/* REUSE: Existing error handling snackbar */}
       <Snackbar
-        open={!!dashboardError}
+        open={!!error}
         autoHideDuration={6000}
         onClose={clearError}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
         <Alert onClose={clearError} severity="error" sx={{ width: '100%' }}>
-          {dashboardError}
+          {error}
         </Alert>
       </Snackbar>
     </AIDashboardLayout>

--- a/client/src/pages/home/components.tsx
+++ b/client/src/pages/home/components.tsx
@@ -1,0 +1,474 @@
+import React from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Chip,
+  LinearProgress,
+  Button,
+  Divider,
+} from '@mui/material';
+import { QuickActionsGrid } from '../../components/ai-dashboard/QuickActionCard';
+import { AITutorCard } from '../../components/ai-dashboard/AITutorCard';
+import type { ContentType } from '../../config/aiDashboardConfig';
+import type {
+  PlanLesson,
+  HeroMetric,
+  SkillInsight,
+  StudyHighlight,
+  DailyGoalProgress,
+  QuickActionLesson,
+} from './selectors';
+import type { FocusToken } from './constants';
+
+const cardBaseSx = {
+  backgroundColor: 'var(--bg-primary)',
+  borderRadius: 'var(--border-radius-medium)',
+  border: '1px solid var(--border-light)',
+  boxShadow: 'var(--shadow-light)',
+};
+
+const chipBaseSx = {
+  borderRadius: 'var(--border-radius-small)',
+  fontWeight: 600,
+};
+
+const statusTokens: Record<string, { label: string; color: string; background: string }> = {
+  not_started: { label: 'Ready', color: 'var(--accent-blue)', background: 'var(--accent-blue-bg)' },
+  in_progress: { label: 'In progress', color: 'var(--accent-amber)', background: 'var(--accent-amber-bg)' },
+  completed: { label: 'Completed', color: 'var(--accent-green)', background: 'var(--accent-green-bg)' },
+  locked: { label: 'Locked', color: 'var(--text-tertiary)', background: 'var(--bg-tertiary)' },
+  review: { label: 'Review', color: 'var(--accent-purple)', background: 'var(--accent-purple-bg)' },
+};
+
+export type PlanOverviewCardProps = {
+  nextLesson?: PlanLesson;
+  focusChips: Array<{ label: string; token: FocusToken }>;
+  dailyGoal: DailyGoalProgress;
+  summary: Array<{ label: string; value: string }>;
+  lastLessonTitle: string;
+  isOffline: boolean;
+  onStartLesson: (lessonId: string, contentType: string) => void;
+};
+
+export const PlanOverviewCard: React.FC<PlanOverviewCardProps> = ({
+  nextLesson,
+  focusChips,
+  dailyGoal,
+  summary,
+  lastLessonTitle,
+  isOffline,
+  onStartLesson,
+}) => {
+  return (
+    <Card sx={{ ...cardBaseSx, borderRadius: 'var(--border-radius-large)', height: '100%' }}>
+      <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-4)' }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-1)' }}>
+          <Typography variant="overline" sx={{ color: 'var(--text-tertiary)', letterSpacing: 1 }}>
+            Up next
+          </Typography>
+          <Typography variant="h5" sx={{ color: 'var(--text-primary)', fontWeight: 600 }}>
+            {nextLesson?.title ?? 'Continue learning'}
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'var(--text-secondary)' }}>
+            {nextLesson?.summary ?? 'Choose a lesson to keep building momentum.'}
+          </Typography>
+        </Box>
+
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--spacing-2)' }}>
+          {focusChips.map(({ label, token }) => (
+            <Chip
+              key={label}
+              label={label}
+              size="small"
+              sx={{ ...chipBaseSx, backgroundColor: token.background, color: token.accent }}
+            />
+          ))}
+        </Box>
+
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-2)' }}>
+          <Typography variant="caption" sx={{ color: 'var(--text-tertiary)', letterSpacing: 0.5 }}>
+            Daily progress
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-3)' }}>
+            <Box sx={{ flex: 1 }}>
+              <LinearProgress
+                variant="determinate"
+                value={dailyGoal.percentage}
+                sx={{
+                  height: 8,
+                  borderRadius: 'var(--border-radius-small)',
+                  backgroundColor: 'var(--bg-tertiary)',
+                  '& .MuiLinearProgress-bar': { backgroundColor: 'var(--accent-purple)' },
+                }}
+              />
+            </Box>
+            <Typography variant="body2" sx={{ fontWeight: 600, color: 'var(--text-primary)' }}>
+              {dailyGoal.percentage}%
+            </Typography>
+          </Box>
+          <Typography variant="caption" sx={{ color: 'var(--text-secondary)' }}>
+            {dailyGoal.current}/{dailyGoal.target} lessons completed today
+          </Typography>
+        </Box>
+
+        <Divider sx={{ borderColor: 'var(--border-light)' }} />
+
+        <Box sx={{ display: 'grid', gap: 'var(--spacing-3)', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))' }}>
+          {summary.map((stat) => (
+            <Box key={stat.label} sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-1)' }}>
+              <Typography variant="caption" sx={{ color: 'var(--text-tertiary)', letterSpacing: 0.5 }}>
+                {stat.label}
+              </Typography>
+              <Typography variant="body1" sx={{ color: 'var(--text-primary)', fontWeight: 600 }}>
+                {stat.value}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-1)' }}>
+          <Typography variant="caption" sx={{ color: 'var(--text-secondary)' }}>
+            Last session: {lastLessonTitle}
+          </Typography>
+          <Button
+            variant="contained"
+            onClick={() => nextLesson && onStartLesson(nextLesson.id, nextLesson.contentType)}
+            disabled={!nextLesson || isOffline}
+            sx={{
+              alignSelf: 'flex-start',
+              textTransform: 'none',
+              fontWeight: 600,
+              borderRadius: 'var(--border-radius-small)',
+              px: 'var(--spacing-5)',
+              py: 'var(--spacing-2)',
+              background: 'var(--accent-purple)',
+              '&:hover': { background: 'var(--accent-purple-light)' },
+              '&.Mui-disabled': { backgroundColor: 'var(--bg-tertiary)', color: 'var(--text-tertiary)' },
+            }}
+          >
+            {isOffline ? 'Offline mode' : 'Resume lesson'}
+          </Button>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+export type MetricsSectionProps = {
+  metrics: HeroMetric[];
+};
+
+export const MetricsSection: React.FC<MetricsSectionProps> = ({ metrics }) => (
+  <Box
+    sx={{
+      display: 'grid',
+      gap: 'var(--spacing-4)',
+      gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))', xl: 'repeat(4, minmax(0, 1fr))' },
+    }}
+  >
+    {metrics.map((metric) => (
+      <Box
+        key={metric.id}
+        sx={{
+          ...cardBaseSx,
+          padding: 'var(--spacing-5)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--spacing-2)',
+        }}
+      >
+        <Typography variant="overline" sx={{ color: 'var(--text-tertiary)', letterSpacing: 0.8 }}>
+          {metric.label}
+        </Typography>
+        <Typography variant="h5" sx={{ color: 'var(--text-primary)', fontWeight: 600 }}>
+          {metric.value}
+        </Typography>
+        <Typography variant="body2" sx={{ color: 'var(--text-secondary)' }}>
+          {metric.helper}
+        </Typography>
+      </Box>
+    ))}
+  </Box>
+);
+
+export type FocusJourneySectionProps = {
+  lessons: PlanLesson[];
+  onLessonClick: (lessonId: string, contentType: string) => void;
+  isOffline: boolean;
+};
+
+export const FocusJourneySection: React.FC<FocusJourneySectionProps> = ({ lessons, onLessonClick, isOffline }) => (
+  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-3)' }}>
+    {lessons.map((lesson) => {
+      const status = statusTokens[lesson.status] ?? statusTokens.not_started;
+      return (
+        <Box
+          key={lesson.id}
+          sx={{
+            ...cardBaseSx,
+            borderRadius: 'var(--border-radius-large)',
+            padding: 'var(--spacing-5)',
+            display: 'grid',
+            gap: { xs: 'var(--spacing-3)', md: 'var(--spacing-5)' },
+            gridTemplateColumns: { xs: '1fr', md: 'minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr)' },
+          }}
+        >
+          <Box sx={{ display: 'flex', gap: 'var(--spacing-3)' }}>
+            <Box
+              aria-hidden
+              sx={{
+                width: 52,
+                height: 52,
+                borderRadius: 'var(--border-radius-medium)',
+                border: `1px solid ${status.color}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: '1.75rem',
+              }}
+            >
+              {lesson.icon}
+            </Box>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-2)' }}>
+              <Typography variant="subtitle1" sx={{ color: 'var(--text-primary)', fontWeight: 600 }}>
+                {lesson.title}
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'var(--text-secondary)' }}>
+                {lesson.summary}
+              </Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--spacing-2)' }}>
+                <Chip
+                  label={lesson.focus}
+                  size="small"
+                  sx={{ ...chipBaseSx, backgroundColor: 'var(--bg-tertiary)', color: 'var(--text-secondary)' }}
+                />
+                <Chip
+                  label={status.label}
+                  size="small"
+                  sx={{ ...chipBaseSx, backgroundColor: status.background, color: status.color }}
+                />
+              </Box>
+            </Box>
+          </Box>
+
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-2)' }}>
+            <Typography variant="caption" sx={{ color: 'var(--text-tertiary)', letterSpacing: 0.5 }}>
+              Lesson details
+            </Typography>
+            <Typography variant="body2" sx={{ color: 'var(--text-secondary)' }}>
+              {lesson.estimatedTime} min • {lesson.difficulty}
+            </Typography>
+          </Box>
+
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-2)' }}>
+            <Typography variant="caption" sx={{ color: 'var(--text-tertiary)', letterSpacing: 0.5 }}>
+              Progress
+            </Typography>
+            <LinearProgress
+              variant="determinate"
+              value={lesson.progress}
+              sx={{
+                height: 8,
+                borderRadius: 'var(--border-radius-small)',
+                backgroundColor: 'var(--bg-tertiary)',
+                '& .MuiLinearProgress-bar': { backgroundColor: status.color },
+              }}
+            />
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => onLessonClick(lesson.id, lesson.contentType)}
+              disabled={isOffline}
+              sx={{ textTransform: 'none', fontWeight: 600, alignSelf: 'flex-start' }}
+            >
+              {isOffline ? 'Offline' : 'Open lesson'}
+            </Button>
+          </Box>
+        </Box>
+      );
+    })}
+  </Box>
+);
+
+export type QuickActionsSectionProps = {
+  title: string;
+  description: string;
+  actions: QuickActionLesson[];
+  onActionClick: (id: string, contentType: ContentType) => void;
+  isOffline: boolean;
+  renderMode?: 'quick-action' | 'lesson-card';
+  showProgress?: boolean;
+};
+
+export const QuickActionsSection: React.FC<QuickActionsSectionProps> = ({
+  title,
+  description,
+  actions,
+  onActionClick,
+  isOffline,
+  renderMode = 'quick-action',
+  showProgress,
+}) => (
+  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-3)' }}>
+    <Typography variant="h5" sx={{ color: 'var(--text-primary)', fontWeight: 600 }}>
+      {title}
+    </Typography>
+    <Typography variant="body2" sx={{ color: 'var(--text-secondary)' }}>
+      {description}
+    </Typography>
+    <QuickActionsGrid
+      actions={actions}
+      onActionClick={onActionClick}
+      disabled={isOffline}
+      renderMode={renderMode}
+      showProgress={showProgress}
+      sx={{ gap: 'var(--spacing-4)' }}
+    />
+  </Box>
+);
+
+export type SkillInsightsSectionProps = {
+  insights: SkillInsight[];
+};
+
+export const SkillInsightsSection: React.FC<SkillInsightsSectionProps> = ({ insights }) => (
+  <Box
+    sx={{
+      display: 'grid',
+      gap: 'var(--spacing-4)',
+      gridTemplateColumns: { xs: '1fr', md: 'repeat(3, minmax(0, 1fr))' },
+    }}
+  >
+    {insights.map((insight) => (
+      <Box
+        key={insight.id}
+        sx={{
+          ...cardBaseSx,
+          backgroundColor: insight.background,
+          padding: 'var(--spacing-5)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--spacing-3)',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Typography variant="subtitle1" sx={{ color: 'var(--text-primary)', fontWeight: 600, display: 'flex', gap: 'var(--spacing-2)' }}>
+            <span role="img" aria-hidden>
+              {insight.icon}
+            </span>
+            {insight.label}
+          </Typography>
+          <Typography variant="body2" sx={{ color: insight.accent, fontWeight: 600 }}>
+            {insight.progress}%
+          </Typography>
+        </Box>
+        <Typography variant="body2" sx={{ color: 'var(--text-secondary)' }}>
+          {insight.helper}
+        </Typography>
+        <LinearProgress
+          variant="determinate"
+          value={insight.progress}
+          sx={{
+            height: 8,
+            borderRadius: 'var(--border-radius-small)',
+            backgroundColor: 'var(--bg-tertiary)',
+            '& .MuiLinearProgress-bar': { backgroundColor: insight.accent },
+          }}
+        />
+      </Box>
+    ))}
+  </Box>
+);
+
+export type TutorAndGuidanceProps = {
+  userName?: string;
+  progressPercentage: number;
+  onStartTutor: () => void;
+  isOffline: boolean;
+  highlights: StudyHighlight[];
+};
+
+export const TutorAndGuidance: React.FC<TutorAndGuidanceProps> = ({
+  userName,
+  progressPercentage,
+  onStartTutor,
+  isOffline,
+  highlights,
+}) => (
+  <Box
+    sx={{
+      display: 'grid',
+      gap: 'var(--spacing-4)',
+      gridTemplateColumns: { xs: '1fr', xl: 'minmax(0, 2fr) minmax(0, 1fr)' },
+    }}
+  >
+    <AITutorCard
+      userName={userName}
+      progressPercentage={progressPercentage}
+      onInteractionStart={onStartTutor}
+      isOffline={isOffline}
+      sx={{ height: '100%' }}
+    />
+
+    <Card sx={{ ...cardBaseSx, borderRadius: 'var(--border-radius-large)' }}>
+      <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-4)' }}>
+        <Box>
+          <Typography variant="overline" sx={{ color: 'var(--text-tertiary)', letterSpacing: 1 }}>
+            Study guidance
+          </Typography>
+          <Typography variant="h6" sx={{ color: 'var(--text-primary)', fontWeight: 600 }}>
+            Micro-actions to try today
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'var(--text-secondary)', mt: 'var(--spacing-1)' }}>
+            Reinforce what you learn with quick, focused routines.
+          </Typography>
+        </Box>
+
+        <Box component="ul" sx={{ listStyle: 'none', m: 0, p: 0, display: 'flex', flexDirection: 'column', gap: 'var(--spacing-3)' }}>
+          {highlights.map((highlight) => (
+            <Box
+              key={highlight.id}
+              component="li"
+              sx={{
+                display: 'flex',
+                gap: 'var(--spacing-3)',
+                alignItems: 'flex-start',
+                backgroundColor: highlight.background,
+                borderRadius: 'var(--border-radius-medium)',
+                border: '1px solid var(--border-light)',
+                padding: 'var(--spacing-4)',
+              }}
+            >
+              <Box
+                aria-hidden
+                sx={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: '50%',
+                  backgroundColor: 'var(--bg-primary)',
+                  border: `1px solid ${highlight.accent}`,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: '1.25rem',
+                }}
+              >
+                {highlight.icon}
+              </Box>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-1)' }}>
+                <Typography variant="subtitle2" sx={{ color: 'var(--text-primary)', fontWeight: 600 }}>
+                  {highlight.title}
+                </Typography>
+                <Typography variant="body2" sx={{ color: 'var(--text-secondary)' }}>
+                  {highlight.description}
+                </Typography>
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </CardContent>
+    </Card>
+  </Box>
+);

--- a/client/src/pages/home/constants.ts
+++ b/client/src/pages/home/constants.ts
@@ -1,0 +1,212 @@
+import type { DailyLearningPlan, ContentRecommendation, CEFRLevel } from '../../types/AIDashboard';
+import type { LessonStatus } from '../../components/ai-dashboard/QuickActionCard';
+
+export type FocusToken = {
+  icon: string;
+  accent: string;
+  background: string;
+};
+
+export type DefaultLesson = {
+  id: string;
+  title: string;
+  description: string;
+  focus: string;
+  estimatedTime: number;
+  type: string;
+  status: LessonStatus;
+  progress: number;
+  difficulty: CEFRLevel;
+};
+
+export const FALLBACK_DAILY_PLAN: DailyLearningPlan = {
+  id: 'fallback-plan',
+  userId: 'demo-user',
+  generatedAt: '2024-01-01T08:00:00.000Z',
+  lessons: [
+    {
+      id: 'conversation-101',
+      title: 'Warm-up conversation',
+      description: 'Practice greeting a friend and asking simple questions.',
+      focus: 'Conversation',
+      estimatedTime: 12,
+      type: 'conversation',
+      status: 'in_progress',
+      progress: 45,
+      difficulty: 'A2',
+    },
+    {
+      id: 'listening-lounge',
+      title: 'Active listening',
+      description: 'Listen for café vocabulary and answer short prompts.',
+      focus: 'Listening',
+      estimatedTime: 10,
+      type: 'listening',
+      status: 'not_started',
+      progress: 0,
+      difficulty: 'A2',
+    },
+    {
+      id: 'grammar-refresh',
+      title: 'Past tense essentials',
+      description: 'Contrast passé composé and imparfait in short stories.',
+      focus: 'Grammar',
+      estimatedTime: 15,
+      type: 'grammar',
+      status: 'not_started',
+      progress: 0,
+      difficulty: 'A2',
+    },
+    {
+      id: 'pronunciation-lab',
+      title: 'Nasal vowel drill',
+      description: 'Repeat and record three sentences with nasal vowels.',
+      focus: 'Pronunciation',
+      estimatedTime: 8,
+      type: 'pronunciation',
+      status: 'locked',
+      progress: 0,
+      difficulty: 'B1',
+    },
+  ] satisfies DefaultLesson[],
+  recommendations: [],
+  estimatedDuration: 45,
+  difficulty: 'A2',
+  metadata: {
+    streakDays: 6,
+    focusAreas: ['Conversation', 'Listening', 'Grammar'],
+    confidenceScore: 0.82,
+  },
+};
+
+export const FALLBACK_RECOMMENDATIONS: ContentRecommendation[] = [
+  {
+    id: 'rec-cafe-dialogue',
+    title: 'Ordering at the café',
+    description: 'Role-play a café order with polite forms and useful filler phrases.',
+    type: 'lesson',
+    difficulty: 'A2',
+    estimatedTime: 15,
+    reason: 'Build on your conversation warm-up with practical phrases.',
+    priority: 'high',
+    tags: ['conversation'],
+    confidenceScore: 0.88,
+  },
+  {
+    id: 'rec-aural-notes',
+    title: 'Listening for key details',
+    description: 'Identify numbers and times in a short train announcement.',
+    type: 'lesson',
+    difficulty: 'A2',
+    estimatedTime: 12,
+    reason: 'Strengthen your listening accuracy before the next lesson.',
+    priority: 'medium',
+    tags: ['listening'],
+    confidenceScore: 0.82,
+  },
+  {
+    id: 'rec-grammar-check',
+    title: 'Passé composé challenge',
+    description: 'Choose the correct tense in daily routine sentences.',
+    type: 'grammar_exercise',
+    difficulty: 'A2',
+    estimatedTime: 10,
+    reason: 'Reinforce tense contrast covered in your plan.',
+    priority: 'medium',
+    tags: ['grammar'],
+    confidenceScore: 0.78,
+  },
+  {
+    id: 'rec-vocab-topup',
+    title: 'Café vocabulary deck',
+    description: 'Revise ten phrases you can use when ordering.',
+    type: 'vocabulary_drill',
+    difficulty: 'A2',
+    estimatedTime: 8,
+    reason: 'Quick boost to match today\'s focus.',
+    priority: 'low',
+    tags: ['vocabulary'],
+    confidenceScore: 0.75,
+  },
+];
+
+export const FOCUS_CONFIG: Record<string, FocusToken> = {
+  conversation: { icon: '💬', accent: 'var(--accent-purple)', background: 'var(--accent-purple-bg)' },
+  listening: { icon: '🎧', accent: 'var(--accent-blue)', background: 'var(--accent-blue-bg)' },
+  grammar: { icon: '📚', accent: 'var(--accent-orange)', background: 'var(--accent-orange-bg)' },
+  vocabulary: { icon: '🔤', accent: 'var(--accent-blue)', background: 'var(--accent-blue-bg)' },
+  pronunciation: { icon: '🗣️', accent: 'var(--accent-green)', background: 'var(--accent-green-bg)' },
+};
+
+export const DEFAULT_FOCUS_TOKEN: FocusToken = {
+  icon: '🎯',
+  accent: 'var(--accent-blue)',
+  background: 'var(--accent-blue-bg)',
+};
+
+export const DEFAULT_SKILL_INSIGHTS = [
+  {
+    id: 'skill-conversation',
+    label: 'Conversation',
+    icon: FOCUS_CONFIG.conversation.icon,
+    accent: FOCUS_CONFIG.conversation.accent,
+    background: FOCUS_CONFIG.conversation.background,
+    progress: 68,
+    helper: 'You sustain longer turns when greeting and closing conversations.',
+  },
+  {
+    id: 'skill-listening',
+    label: 'Listening',
+    icon: FOCUS_CONFIG.listening.icon,
+    accent: FOCUS_CONFIG.listening.accent,
+    background: FOCUS_CONFIG.listening.background,
+    progress: 62,
+    helper: 'You catch key details from native-speed clips more often.',
+  },
+  {
+    id: 'skill-grammar',
+    label: 'Grammar',
+    icon: FOCUS_CONFIG.grammar.icon,
+    accent: FOCUS_CONFIG.grammar.accent,
+    background: FOCUS_CONFIG.grammar.background,
+    progress: 54,
+    helper: 'Verb endings are more consistent in your practice responses.',
+  },
+] as const;
+
+export const DEFAULT_STUDY_GUIDANCE = [
+  {
+    id: 'guidance-voice-note',
+    icon: '🎙️',
+    title: 'Send a quick voice note',
+    description: 'Record a 30-second café order to a friend and compare it with the model answer.',
+    accent: 'var(--accent-purple)',
+    background: 'var(--accent-purple-bg)',
+  },
+  {
+    id: 'guidance-flashcards',
+    icon: '🗂️',
+    title: 'Review your flashcards',
+    description: 'Run through the café deck to keep the phrases top of mind.',
+    accent: 'var(--accent-blue)',
+    background: 'var(--accent-blue-bg)',
+  },
+  {
+    id: 'guidance-journal',
+    icon: '📓',
+    title: 'Write three lines',
+    description: 'Describe what you ordered last weekend using both past tenses.',
+    accent: 'var(--accent-orange)',
+    background: 'var(--accent-orange-bg)',
+  },
+] as const;
+
+export const DEFAULT_USER_SNAPSHOT = {
+  userName: undefined as string | undefined,
+  cefrLevel: 'A2' as CEFRLevel,
+  progressPercentage: 72,
+  streak: 6,
+  weeklyXp: 320,
+  dailyGoal: { current: 2, target: 3 },
+  lastLessonTitle: 'Ordering coffee politely',
+};

--- a/client/src/pages/home/selectors.ts
+++ b/client/src/pages/home/selectors.ts
@@ -1,0 +1,308 @@
+import { AI_DASHBOARD_CONFIG, type ContentType } from '../../config/aiDashboardConfig';
+import type { ContentRecommendation, DailyLearningPlan } from '../../types/AIDashboard';
+import type { DifficultyLevel, LessonStatus } from '../../components/ai-dashboard/QuickActionCard';
+import {
+  FALLBACK_DAILY_PLAN,
+  FALLBACK_RECOMMENDATIONS,
+  FOCUS_CONFIG,
+  DEFAULT_FOCUS_TOKEN,
+  DEFAULT_SKILL_INSIGHTS,
+  DEFAULT_STUDY_GUIDANCE,
+  DEFAULT_USER_SNAPSHOT,
+  type FocusToken,
+} from './constants';
+
+export type PlanLesson = {
+  id: string;
+  title: string;
+  summary: string;
+  focus: string;
+  estimatedTime: number;
+  status: LessonStatus;
+  difficulty: string;
+  icon: string;
+  progress: number;
+  contentType: string;
+};
+
+export type HeroMetric = {
+  id: string;
+  label: string;
+  value: string;
+  helper: string;
+};
+
+export type SkillInsight = {
+  id: string;
+  label: string;
+  icon: string;
+  accent: string;
+  background: string;
+  progress: number;
+  helper: string;
+};
+
+export type StudyHighlight = {
+  id: string;
+  icon: string;
+  title: string;
+  description: string;
+  accent: string;
+  background: string;
+};
+
+export type DailyGoalProgress = {
+  current: number;
+  target: number;
+  percentage: number;
+};
+
+export type UserSnapshot = typeof DEFAULT_USER_SNAPSHOT;
+
+export type QuickActionLesson = {
+  id: string;
+  icon: string;
+  title: string;
+  description: string;
+  contentType: ContentType;
+  estimatedTime: number;
+  disabled?: boolean;
+  progress?: number;
+  xpReward?: number;
+  difficulty?: DifficultyLevel;
+  status?: LessonStatus;
+  aiPersonalization?: string;
+};
+
+const RECOMMENDATION_META: Record<ContentRecommendation['type'], { icon: string }> = {
+  lesson: { icon: '📘' },
+  vocabulary_drill: { icon: '🗂️' },
+  grammar_exercise: { icon: '✏️' },
+};
+
+const STATUS_FALLBACK: LessonStatus = 'not_started';
+
+const PROGRESS_HELPERS = [
+  'Your responses sound more natural each session.',
+  'You pick out key details faster than last week.',
+  'Accuracy keeps improving with steady practice.',
+];
+
+const clampProgress = (value: unknown): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, Math.round(value)));
+};
+
+const resolveFocusToken = (focus?: string): FocusToken => {
+  if (!focus) {
+    return DEFAULT_FOCUS_TOKEN;
+  }
+
+  const normalized = focus.toLowerCase().split(' ')[0];
+  return FOCUS_CONFIG[normalized] ?? DEFAULT_FOCUS_TOKEN;
+};
+
+const mapDifficultyToBadge = (difficulty: string | undefined): DifficultyLevel => {
+  if (!difficulty) return 'beginner';
+  const upper = difficulty.toUpperCase();
+  if (upper.startsWith('C')) return 'advanced';
+  if (upper.startsWith('B')) return 'intermediate';
+  return 'beginner';
+};
+
+export const resolveActivePlan = (plan?: DailyLearningPlan | null): DailyLearningPlan => {
+  if (!plan || !Array.isArray(plan.lessons) || plan.lessons.length === 0) {
+    return FALLBACK_DAILY_PLAN;
+  }
+
+  return {
+    ...FALLBACK_DAILY_PLAN,
+    ...plan,
+    lessons: plan.lessons,
+    metadata: {
+      ...FALLBACK_DAILY_PLAN.metadata,
+      ...plan.metadata,
+    },
+  };
+};
+
+export const selectFocusAreas = (plan: DailyLearningPlan): string[] => {
+  const focusAreas = plan.metadata?.focusAreas;
+  if (Array.isArray(focusAreas) && focusAreas.length > 0) {
+    return focusAreas;
+  }
+  return FALLBACK_DAILY_PLAN.metadata?.focusAreas ?? [];
+};
+
+export const buildPlanLessons = (plan: DailyLearningPlan, focusAreas: string[]): PlanLesson[] => {
+  return plan.lessons.map((lesson: any, index: number) => {
+    const focusLabel = lesson.focus ?? focusAreas[index % focusAreas.length] ?? 'Lesson';
+    const focusToken = resolveFocusToken(focusLabel);
+    const status = (lesson.status ?? STATUS_FALLBACK) as LessonStatus;
+
+    const derivedProgress = clampProgress(
+      typeof lesson.progress === 'number'
+        ? lesson.progress
+        : status === 'completed'
+          ? 100
+          : status === 'in_progress'
+            ? 40
+            : 0,
+    );
+
+    return {
+      id: String(lesson.id ?? `lesson-${index}`),
+      title: String(lesson.title ?? `Lesson ${index + 1}`),
+      summary: String(lesson.description ?? lesson.summary ?? `Focus on ${focusLabel.toLowerCase()}.`),
+      focus: focusLabel,
+      estimatedTime: typeof lesson.estimatedTime === 'number' ? lesson.estimatedTime : 15,
+      status,
+      difficulty: String(lesson.difficulty ?? plan.difficulty ?? 'A2'),
+      icon: focusToken.icon,
+      progress: derivedProgress,
+      contentType: String(lesson.type ?? 'lesson'),
+    };
+  });
+};
+
+export const selectNextLesson = (lessons: PlanLesson[]): PlanLesson | undefined => {
+  return lessons.find((lesson) => lesson.status === 'in_progress' || lesson.status === 'not_started')
+    ?? lessons[0];
+};
+
+export const calculateDailyGoal = (snapshot: UserSnapshot): DailyGoalProgress => {
+  const { current, target } = snapshot.dailyGoal;
+  if (!target) {
+    return { current, target, percentage: 0 };
+  }
+  const percentage = Math.min(100, Math.round((current / target) * 100));
+  return { current, target, percentage };
+};
+
+export const calculatePlanConfidence = (plan: DailyLearningPlan): number => {
+  const confidence = plan.metadata?.confidenceScore ?? FALLBACK_DAILY_PLAN.metadata?.confidenceScore ?? 0;
+  return Math.round(confidence * 100);
+};
+
+export const buildHeroMetrics = (snapshot: UserSnapshot, planConfidence: number): HeroMetric[] => [
+  {
+    id: 'daily-goal',
+    label: 'Daily goal',
+    value: `${snapshot.dailyGoal.current}/${snapshot.dailyGoal.target}`,
+    helper: snapshot.dailyGoal.current >= snapshot.dailyGoal.target
+      ? 'Goal completed – bravo!'
+      : `${snapshot.dailyGoal.target - snapshot.dailyGoal.current} lesson(s) left`,
+  },
+  {
+    id: 'weekly-xp',
+    label: 'Weekly XP',
+    value: `${snapshot.weeklyXp}`,
+    helper: 'Keep pace to reach 500 XP',
+  },
+  {
+    id: 'streak',
+    label: 'Current streak',
+    value: `${snapshot.streak} days`,
+    helper: 'Consistency unlocks badges',
+  },
+  {
+    id: 'confidence',
+    label: 'AI confidence',
+    value: `${planConfidence}%`,
+    helper: 'Personalised to your goals',
+  },
+];
+
+export const buildPlanSummary = (
+  snapshot: UserSnapshot,
+  plan: DailyLearningPlan,
+  lessons: PlanLesson[],
+  planConfidence: number,
+) => [
+  { label: 'CEFR level', value: snapshot.cefrLevel },
+  { label: 'Plan duration', value: `${plan.estimatedDuration} min` },
+  { label: 'Activities', value: `${lessons.length}` },
+  { label: 'Confidence', value: `${planConfidence}%` },
+];
+
+export const buildSkillInsights = (focusAreas: string[]): SkillInsight[] => {
+  if (!focusAreas.length) {
+    return DEFAULT_SKILL_INSIGHTS.map((insight) => ({ ...insight }));
+  }
+
+  return focusAreas.slice(0, 3).map((focus, index) => {
+    const token = resolveFocusToken(focus);
+    const base = DEFAULT_SKILL_INSIGHTS[index];
+    const helper = PROGRESS_HELPERS[index % PROGRESS_HELPERS.length];
+
+    return {
+      id: `insight-${focus.toLowerCase().replace(/\s+/g, '-')}`,
+      label: focus,
+      icon: token.icon,
+      accent: token.accent,
+      background: token.background,
+      progress: base ? base.progress : 55 + index * 8,
+      helper,
+    };
+  });
+};
+
+export const buildStudyGuidance = (focusAreas: string[]): StudyHighlight[] => {
+  if (!focusAreas.length) {
+    return DEFAULT_STUDY_GUIDANCE.map((item) => ({ ...item }));
+  }
+
+  return focusAreas.slice(0, 3).map((focus, index) => {
+    const token = resolveFocusToken(focus);
+    const fallback = DEFAULT_STUDY_GUIDANCE[index];
+
+    return {
+      id: `guidance-${focus.toLowerCase().replace(/\s+/g, '-')}`,
+      icon: token.icon,
+      title: `${focus} micro-practice`,
+      description: fallback?.description ?? `Spend five minutes reviewing ${focus.toLowerCase()}.`,
+      accent: token.accent,
+      background: token.background,
+    };
+  });
+};
+
+export const mapRecommendationsToLessons = (
+  recommendations: ContentRecommendation[],
+  isOffline: boolean,
+): QuickActionLesson[] => {
+  const source = recommendations.length > 0 ? recommendations : FALLBACK_RECOMMENDATIONS;
+
+  return source.slice(0, AI_DASHBOARD_CONFIG.DEFAULTS.MAX_RECOMMENDATIONS).map((item) => {
+    const meta = RECOMMENDATION_META[item.type];
+    const badgeDifficulty = mapDifficultyToBadge(item.difficulty);
+    const progress = item.confidenceScore ? Math.round(item.confidenceScore * 100) : undefined;
+
+    return {
+      id: item.id,
+      icon: meta?.icon ?? '📘',
+      title: item.title,
+      description: item.description,
+      contentType: item.type,
+      estimatedTime: item.estimatedTime ?? AI_DASHBOARD_CONFIG.DEFAULTS.ESTIMATED_TIME,
+      disabled: isOffline,
+      progress,
+      difficulty: badgeDifficulty,
+      status: STATUS_FALLBACK,
+      aiPersonalization: item.reason,
+    };
+  });
+};
+
+export const mapQuickActions = (isOffline: boolean) => {
+  return AI_DASHBOARD_CONFIG.QUICK_ACTIONS.map((action) => ({
+    ...action,
+    disabled: isOffline,
+  }));
+};
+
+export const getUserSnapshot = (): UserSnapshot => DEFAULT_USER_SNAPSHOT;
+
+export const getFocusToken = (focus: string): FocusToken => resolveFocusToken(focus);


### PR DESCRIPTION
## Summary
- refactor the home dashboard into focused selector utilities and presentational components that reuse design tokens
- streamline HomePage to use the new modules, keeping styling consistent while removing inline sprawl
- fix the AI dashboard hook import to reference the existing TypeScript api module

## Testing
- npm --prefix client run test -- --watchAll=false *(fails: jest environment configuration missing in repo)*
- npm --prefix client run build *(fails: existing Vite build cannot resolve @21st-extension/toolbar-react)*

------
https://chatgpt.com/codex/tasks/task_e_68cae1fbe8b8832398ef39b978e7cd7a